### PR TITLE
feat: adding list API continued

### DIFF
--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -3,6 +3,9 @@ namespace Momento\Cache\CacheOperationTypes;
 
 use Cache_client\_GetResponse;
 use Cache_client\_ListFetchResponse;
+use Cache_client\_ListLengthResponse;
+use Cache_client\_ListPopBackResponse;
+use Cache_client\_ListPopFrontResponse;
 use Control_client\_ListCachesResponse;
 use Cache_client\_SetResponse;
 use Momento\Cache\Errors\MomentoErrorCode;
@@ -48,6 +51,12 @@ trait ErrorBody {
     {
         return $this->message;
     }
+
+    public function __toString()
+    {
+        return parent::__toString() . ": " . $this->message;
+    }
+
 }
 
 abstract class ResponseBase
@@ -81,6 +90,11 @@ abstract class ResponseBase
     protected function isMiss() : bool
     {
         return get_class($this) == "{$this->baseType}Miss";
+    }
+
+    public function __toString()
+    {
+        return get_class($this);
     }
 }
 
@@ -195,6 +209,12 @@ class ListCachesResponseSuccess extends ListCachesResponse
     {
         return $this->nextToken;
     }
+
+    public function __toString()
+    {
+        $cacheNames = array_map(fn($i) => $i->name(), $this->caches);
+        return get_class($this) . ": " . join(', ', $cacheNames);
+    }
 }
 
 class ListCachesResponseError extends ListCachesResponse
@@ -241,6 +261,10 @@ class CacheSetResponseSuccess extends CacheSetResponse
         return $this->value;
     }
 
+    public function __toString()
+    {
+        return get_class($this) . ": key {$this->key} = {$this->value}";
+    }
 }
 
 class CacheSetResponseError extends CacheSetResponse
@@ -290,6 +314,10 @@ class CacheGetResponseHit extends CacheGetResponse
         return $this->value;
     }
 
+    public function __toString()
+    {
+        return parent::__toString() . ": {$this->value}";
+    }
 }
 
 class CacheGetResponseMiss extends CacheGetResponse { }
@@ -358,6 +386,7 @@ class CacheListFetchResponseHit extends CacheListFetchResponse
 {
 
     private array $values = [];
+    private int $count;
 
     public function __construct(_ListFetchResponse $response)
     {
@@ -368,6 +397,7 @@ class CacheListFetchResponseHit extends CacheListFetchResponse
             {
                 $this->values[] = $value;
             }
+            $this->count = count($this->values);
         }
     }
 
@@ -376,6 +406,10 @@ class CacheListFetchResponseHit extends CacheListFetchResponse
         return $this->values;
     }
 
+    public function __toString()
+    {
+        return parent::__toString() . ": {$this->count} items";
+    }
 }
 
 class CacheListFetchResponseMiss extends CacheListFetchResponse { }
@@ -441,3 +475,209 @@ class CacheListPushBackResponseError extends CacheListPushBackResponse
     use ErrorBody;
 }
 
+abstract class CacheListPopFrontResponse extends ResponseBase
+{
+    public function asHit() : CacheListPopFrontResponseHit|null
+    {
+        if ($this->isHit())
+        {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asMiss() : CacheListPopFrontResponseMiss|null
+    {
+        if ($this->isMiss())
+        {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asError() : CacheListPopFrontResponseError|null
+    {
+        if ($this->isError())
+        {
+            return $this;
+        }
+        return null;
+    }
+}
+
+class CacheListPopFrontResponseHit extends CacheListPopFrontResponse {
+    private string $value;
+
+    public function __construct(_ListPopFrontResponse $response)
+    {
+        parent::__construct();
+        $this->value = $response->getFound()->getFront();
+    }
+
+    public function value() : string
+    {
+        return $this->value;
+    }
+
+    public function __toString()
+    {
+        return parent::__toString() . ": {$this->value}";
+    }
+}
+
+class CacheListPopFrontResponseMiss extends CacheListPopFrontResponse { }
+
+class CacheListPopFrontResponseError extends CacheListPopFrontResponse
+{
+    use ErrorBody;
+}
+
+abstract class CacheListPopBackResponse extends ResponseBase
+{
+    public function asHit() : CacheListPopBackResponseHit|null
+    {
+        if ($this->isHit())
+        {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asMiss() : CacheListPopBackResponseMiss|null
+    {
+        if ($this->isMiss())
+        {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asError() : CacheListPopBackResponseError|null
+    {
+        if ($this->isError())
+        {
+            return $this;
+        }
+        return null;
+    }
+}
+
+class CacheListPopBackResponseHit extends CacheListPopBackResponse {
+    private string $value;
+
+    public function __construct(_ListPopBackResponse $response)
+    {
+        parent::__construct();
+        $this->value = $response->getFound()->getBack();
+    }
+
+    public function value() : string
+    {
+        return $this->value;
+    }
+
+    public function __toString()
+    {
+        return parent::__toString() . ": {$this->value}";
+    }
+}
+
+class CacheListPopBackResponseMiss extends CacheListPopBackResponse { }
+
+class CacheListPopBackResponseError extends CacheListPopBackResponse
+{
+    use ErrorBody;
+}
+
+abstract class CacheListRemoveValueResponse extends ResponseBase {
+    public function asSuccess(): CacheListRemoveValueResponseSuccess|null
+    {
+        if ($this->isSuccess()) {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asError(): CacheListRemoveValueResponseError|null
+    {
+        if ($this->isError()) {
+            return $this;
+        }
+        return null;
+    }
+}
+
+class CacheListRemoveValueResponseSuccess extends CacheListRemoveValueResponse { }
+
+class CacheListRemoveValueResponseError extends CacheListRemoveValueResponse
+{
+    use ErrorBody;
+}
+
+abstract class CacheListLengthResponse extends ResponseBase {
+    public function asSuccess(): CacheListLengthResponseSuccess|null
+    {
+        if ($this->isSuccess()) {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asError(): CacheListLengthResponseError|null
+    {
+        if ($this->isError()) {
+            return $this;
+        }
+        return null;
+    }
+}
+
+class CacheListLengthResponseSuccess extends CacheListLengthResponse {
+    private int $length;
+
+    public function __construct(_ListLengthResponse $response)
+    {
+        parent::__construct();
+        $this->length = $response->getFound() ? $response->getFound()->getLength() : 0;
+    }
+
+    public function length() : int
+    {
+        return $this->length;
+    }
+
+    public function __toString()
+    {
+        return parent::__toString() . ": {$this->length}";
+    }
+}
+
+class CacheListLengthResponseError extends CacheListLengthResponse
+{
+    use ErrorBody;
+}
+
+abstract class CacheListEraseResponse extends ResponseBase {
+    public function asSuccess(): CacheListEraseResponseSuccess|null
+    {
+        if ($this->isSuccess()) {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asError(): CacheListEraseResponseError|null
+    {
+        if ($this->isError()) {
+            return $this;
+        }
+        return null;
+    }
+}
+
+class CacheListEraseResponseSuccess extends CacheListEraseResponse { }
+
+class CacheListEraseResponseError extends CacheListEraseResponse
+{
+    use ErrorBody;
+}

--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -3,9 +3,19 @@
 namespace Momento\Cache;
 
 use Momento\Auth\ICredentialProvider;
+use Momento\Cache\CacheOperationTypes\CacheDeleteResponse;
+use Momento\Cache\CacheOperationTypes\CacheGetResponse;
 use Momento\Cache\CacheOperationTypes\CacheListFetchResponse;
+use Momento\Cache\CacheOperationTypes\CacheListLengthResponse;
+use Momento\Cache\CacheOperationTypes\CacheListPopBackResponse;
+use Momento\Cache\CacheOperationTypes\CacheListPopFrontResponse;
 use Momento\Cache\CacheOperationTypes\CacheListPushBackResponse;
 use Momento\Cache\CacheOperationTypes\CacheListPushFrontResponse;
+use Momento\Cache\CacheOperationTypes\CacheListRemoveValueResponse;
+use Momento\Cache\CacheOperationTypes\CacheSetResponse;
+use Momento\Cache\CacheOperationTypes\CreateCacheResponse;
+use Momento\Cache\CacheOperationTypes\DeleteCacheResponse;
+use Momento\Cache\CacheOperationTypes\ListCachesResponse;
 
 class SimpleCacheClient
 {
@@ -17,7 +27,7 @@ class SimpleCacheClient
      * @param int $defaultTtlSeconds: Default Time to Live for the item in Cache
      * @param ?int $dataClientOperationTimeoutMs: msecs after which requests should be cancelled due to timeout
      */
-    function __construct(
+    public function __construct(
         ICredentialProvider $authProvider, int $defaultTtlSeconds, ?int $dataClientOperationTimeoutMs=null
     ) {
         $this->controlClient = new _ScsControlClient($authProvider->getAuthToken(), $authProvider->getControlEndpoint());
@@ -29,32 +39,32 @@ class SimpleCacheClient
         );
     }
 
-    public function createCache(string $cacheName) : CacheOperationTypes\CreateCacheResponse
+    public function createCache(string $cacheName) : CreateCacheResponse
     {
         return $this->controlClient->createCache($cacheName);
     }
 
-    public function listCaches(?string $nextToken=null) : CacheOperationTypes\ListCachesResponse
+    public function listCaches(?string $nextToken=null) : ListCachesResponse
     {
         return $this->controlClient->listCaches($nextToken);
     }
 
-    public function deleteCache(string $cacheName) : CacheOperationTypes\DeleteCacheResponse
+    public function deleteCache(string $cacheName) : DeleteCacheResponse
     {
         return $this->controlClient->deleteCache($cacheName);
     }
 
-    public function set(string $cacheName, string $key, string $value, int $ttlSeconds=0) : CacheOperationTypes\CacheSetResponse
+    public function set(string $cacheName, string $key, string $value, int $ttlSeconds=0) : CacheSetResponse
     {
         return $this->dataClient->set($cacheName, $key, $value, $ttlSeconds);
     }
 
-    public function get(string $cacheName, string $key) : CacheOperationTypes\CacheGetResponse
+    public function get(string $cacheName, string $key) : CacheGetResponse
     {
         return $this->dataClient->get($cacheName, $key);
     }
 
-    public function delete(string $cacheName, string $key) : CacheOperationTypes\CacheDeleteResponse
+    public function delete(string $cacheName, string $key) : CacheDeleteResponse
     {
         return $this->dataClient->delete($cacheName, $key);
     }
@@ -65,16 +75,41 @@ class SimpleCacheClient
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string$value, bool $refreshTtl, ?int $ttlSeconds=null, ?int $truncateBackToSize=null
+        string $cacheName, string $listName, string $value, bool $refreshTtl, ?int $ttlSeconds=null, ?int $truncateBackToSize=null
     ) : CacheListPushFrontResponse
     {
         return $this->dataClient->listPushFront($cacheName, $listName, $value, $refreshTtl, $truncateBackToSize, $ttlSeconds);
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string$value, bool $refreshTtl, ?int $ttlSeconds=null, ?int $truncateFrontToSize=null
+        string $cacheName, string $listName, string $value, bool $refreshTtl, ?int $ttlSeconds=null, ?int $truncateFrontToSize=null
     ) : CacheListPushBackResponse
     {
         return $this->dataClient->listPushBack($cacheName, $listName, $value, $refreshTtl, $truncateFrontToSize, $ttlSeconds);
+    }
+
+    public function listPopFront(string $cacheName, string $listName) : CacheListPopFrontResponse
+    {
+        return $this->dataClient->listPopFront($cacheName, $listName);
+    }
+
+    public function listPopBack(string $cacheName, string $listName) : CacheListPopBackResponse
+    {
+        return $this->dataClient->listPopBack($cacheName, $listName);
+    }
+
+    public function listRemoveValue(string $cacheName, string $listName, string $value) : CacheListRemoveValueResponse
+    {
+        return $this->dataClient->listRemoveValue($cacheName, $listName, $value);
+    }
+
+    public function listLength(string $cacheName, string $listName) : CacheListLengthResponse
+    {
+        return $this->dataClient->listLength($cacheName, $listName);
+    }
+
+    public function listErase(string $cacheName, string $listName, ?int $beginIndex=null, ?int $count=null)
+    {
+        return $this->dataClient->listErase($cacheName, $listName, $beginIndex, $count);
     }
 }

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -3,9 +3,15 @@ namespace Momento\Cache;
 
 use Cache_client\_DeleteRequest;
 use Cache_client\_GetRequest;
+use Cache_client\_ListEraseRequest;
 use Cache_client\_ListFetchRequest;
+use Cache_client\_ListLengthRequest;
+use Cache_client\_ListPopBackRequest;
+use Cache_client\_ListPopFrontRequest;
 use Cache_client\_ListPushBackRequest;
 use Cache_client\_ListPushFrontRequest;
+use Cache_client\_ListRange;
+use Cache_client\_ListRemoveRequest;
 use Cache_client\_SetRequest;
 
 use Cache_client\ECacheResult;
@@ -17,27 +23,44 @@ use Momento\Cache\CacheOperationTypes\CacheGetResponse;
 use Momento\Cache\CacheOperationTypes\CacheGetResponseError;
 use Momento\Cache\CacheOperationTypes\CacheGetResponseHit;
 use Momento\Cache\CacheOperationTypes\CacheGetResponseMiss;
-use Momento\Cache\CacheOperationTypes\CacheGetStatus;
+use Momento\Cache\CacheOperationTypes\CacheListEraseResponse;
+use Momento\Cache\CacheOperationTypes\CacheListEraseResponseError;
+use Momento\Cache\CacheOperationTypes\CacheListEraseResponseSuccess;
 use Momento\Cache\CacheOperationTypes\CacheListFetchResponse;
 use Momento\Cache\CacheOperationTypes\CacheListFetchResponseError;
 use Momento\Cache\CacheOperationTypes\CacheListFetchResponseHit;
 use Momento\Cache\CacheOperationTypes\CacheListFetchResponseMiss;
-use Momento\Cache\CacheOperationTypes\CacheListFetchResponseSuccess;
+use Momento\Cache\CacheOperationTypes\CacheListLengthResponse;
+use Momento\Cache\CacheOperationTypes\CacheListLengthResponseError;
+use Momento\Cache\CacheOperationTypes\CacheListLengthResponseSuccess;
+use Momento\Cache\CacheOperationTypes\CacheListPopBackResponse;
+use Momento\Cache\CacheOperationTypes\CacheListPopBackResponseError;
+use Momento\Cache\CacheOperationTypes\CacheListPopBackResponseHit;
+use Momento\Cache\CacheOperationTypes\CacheListPopBackResponseMiss;
+use Momento\Cache\CacheOperationTypes\CacheListPopFrontResponse;
+use Momento\Cache\CacheOperationTypes\CacheListPopFrontResponseError;
+use Momento\Cache\CacheOperationTypes\CacheListPopFrontResponseHit;
+use Momento\Cache\CacheOperationTypes\CacheListPopFrontResponseMiss;
 use Momento\Cache\CacheOperationTypes\CacheListPushBackResponse;
 use Momento\Cache\CacheOperationTypes\CacheListPushBackResponseError;
 use Momento\Cache\CacheOperationTypes\CacheListPushBackResponseSuccess;
 use Momento\Cache\CacheOperationTypes\CacheListPushFrontResponse;
 use Momento\Cache\CacheOperationTypes\CacheListPushFrontResponseError;
 use Momento\Cache\CacheOperationTypes\CacheListPushFrontResponseSuccess;
+use Momento\Cache\CacheOperationTypes\CacheListRemoveValueResponse;
+use Momento\Cache\CacheOperationTypes\CacheListRemoveValueResponseError;
+use Momento\Cache\CacheOperationTypes\CacheListRemoveValueResponseSuccess;
 use Momento\Cache\CacheOperationTypes\CacheSetResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetResponseError;
 use Momento\Cache\CacheOperationTypes\CacheSetResponseSuccess;
-use Momento\Cache\CacheOperationTypes\CreateCacheResponseError;
 use Momento\Cache\Errors\InternalServerError;
 use Momento\Cache\Errors\SdkError;
 use Momento\Cache\Errors\UnknownError;
 use Momento\Utilities\_ErrorConverter;
+use PHPUnit\Framework\InvalidArgumentException;
 use function Momento\Utilities\validateListName;
+use function Momento\Utilities\validateRange;
+use function Momento\Utilities\validateTruncateSize;
 use function Momento\Utilities\validateTtl;
 use function Momento\Utilities\validateCacheName;
 use function Momento\Utilities\validateOperationTimeout;
@@ -175,6 +198,7 @@ class _ScsDataClient
         try {
             validateCacheName($cacheName);
             validateListName($listName);
+            validateTruncateSize($truncateBackToSize);
             $ttlMillis = $this->ttlToMillis($ttlSeconds);
             $listPushFrontRequest = new _ListPushFrontRequest();
             $listPushFrontRequest->setListName($listName);
@@ -203,6 +227,7 @@ class _ScsDataClient
         try {
             validateCacheName($cacheName);
             validateListName($listName);
+            validateTruncateSize($truncateFrontToSize);
             $ttlMillis = $this->ttlToMillis($ttlSeconds);
             $listPushBackRequest = new _ListPushBackRequest();
             $listPushBackRequest->setListName($listName);
@@ -224,4 +249,119 @@ class _ScsDataClient
         return new CacheListPushBackResponseSuccess();
     }
 
+    public function listPopFront(string $cacheName, string $listName) : CacheListPopFrontResponse
+    {
+        try {
+            validateCacheName($cacheName);
+            validateListName($listName);
+            $listPopFrontRequest = new _ListPopFrontRequest();
+            $listPopFrontRequest->setListName($listName);
+            $call = $this->grpcManager->client->ListPopFront(
+                $listPopFrontRequest, ["cache"=>[$cacheName]], ["timeout" => $this->deadline_seconds * self::$TIMEOUT_MULTIPLIER]
+            );
+            $response = $this->processCall($call);
+        } catch (SdkError $e) {
+            return new CacheListPopFrontResponseError($e);
+        } catch (\Exception $e) {
+            return new CacheListPopFrontResponseError(new UnknownError($e->getMessage()));
+        }
+        if (!$response->hasFound())
+        {
+            return new CacheListPopFrontResponseMiss();
+        }
+        return new CacheListPopFrontResponseHit($response);
+    }
+
+    public function listPopBack(string $cacheName, string $listName) : CacheListPopBackResponse
+    {
+        try {
+            validateCacheName($cacheName);
+            validateListName($listName);
+            $listPopBackRequest = new _ListPopBackRequest();
+            $listPopBackRequest->setListName($listName);
+            $call = $this->grpcManager->client->ListPopBack(
+                $listPopBackRequest, ["cache"=>[$cacheName]], ["timeout" => $this->deadline_seconds * self::$TIMEOUT_MULTIPLIER]
+            );
+            $response = $this->processCall($call);
+        } catch (SdkError $e) {
+            return new CacheListPopBackResponseError($e);
+        } catch (\Exception $e) {
+            return new CacheListPopBackResponseError(new UnknownError($e->getMessage()));
+        }
+        if (!$response->hasFound())
+        {
+            return new CacheListPopBackResponseMiss();
+        }
+        return new CacheListPopBackResponseHit($response);
+    }
+
+    public function listRemoveValue(string $cacheName, string $listName, string $value) : CacheListRemoveValueResponse
+    {
+        try {
+            validateCacheName($cacheName);
+            validateListName($listName);
+            $listRemoveValueRequest = new _ListRemoveRequest();
+            $listRemoveValueRequest->setListName($listName);
+            $listRemoveValueRequest->setAllElementsWithValue($value);
+            $call = $this->grpcManager->client->ListRemove(
+                $listRemoveValueRequest, ["cache"=>[$cacheName]], ["timeout" => $this->deadline_seconds * self::$TIMEOUT_MULTIPLIER]
+            );
+            $this->processCall($call);
+        } catch (SdkError $e) {
+            return new CacheListRemoveValueResponseError($e);
+        } catch (\Exception $e) {
+            return new CacheListRemoveValueResponseError(new UnknownError($e->getMessage()));
+        }
+        return new CacheListRemoveValueResponseSuccess();
+    }
+
+    public function listLength(string $cacheName, string $listName) : CacheListLengthResponse
+    {
+        try {
+            validateCacheName($cacheName);
+            validateListName($listName);
+            $listLengthRequest = new _ListLengthRequest();
+            $listLengthRequest->setListName($listName);
+            $call = $this->grpcManager->client->ListLength(
+                $listLengthRequest, ["cache"=>[$cacheName]], ["timeout" => $this->deadline_seconds * self::$TIMEOUT_MULTIPLIER]
+            );
+            $response = $this->processCall($call);
+        } catch (SdkError $e) {
+            return new CacheListLengthResponseError($e);
+        } catch (\Exception $e) {
+            return new CacheListLengthResponseError(new UnknownError($e->getMessage()));
+        }
+        return new CacheListLengthResponseSuccess($response);
+    }
+
+    public function listErase(string $cacheName, string $listName, ?int $beginIndex=null, ?int $count=null) : CacheListEraseResponse
+    {
+        try {
+            validateCacheName($cacheName);
+            validateListName($listName);
+            validateRange($beginIndex, $count);
+            $listEraseRequest = new _ListEraseRequest();
+            $listEraseRequest->setListName($listName);
+            if (!is_null($beginIndex) && !is_null($count)) {
+                $listRanges = new _ListEraseRequest\_ListRanges();
+                $listRange = new _ListRange();
+                $listRange->setBeginIndex($beginIndex);
+                $listRange->setCount($count);
+                $listRanges->setRanges([$listRange]);
+                $listEraseRequest->setSome($listRanges);
+            } else {
+                $all = new _ListEraseRequest\_All();
+                $listEraseRequest->setAll($all);
+            }
+            $call = $this->grpcManager->client->ListErase(
+                $listEraseRequest, ["cache"=>[$cacheName]], ["timeout" => $this->deadline_seconds * self::$TIMEOUT_MULTIPLIER]
+            );
+            $this->processCall($call);
+        } catch (SdkError $e) {
+            return new CacheListEraseResponseError($e);
+        } catch (\Exception $e) {
+            return new CacheListEraseResponseError(new UnknownError($e->getMessage()));
+        }
+        return new CacheListEraseResponseSuccess();
+    }
 }

--- a/src/Utilities/_DataValidation.php
+++ b/src/Utilities/_DataValidation.php
@@ -59,3 +59,41 @@ if (!function_exists('validateOperationTimeout'))
         }
     }
 }
+
+if (!function_exists('validateTruncateSize'))
+{
+    function validateTruncateSize(?int $truncateSize=null)
+    {
+        if ($truncateSize === null)
+        {
+            return;
+        }
+        if ($truncateSize <= 0)
+        {
+            throw new InvalidArgumentError("Truncate size must be greater than zero.");
+        }
+    }
+}
+
+if (!function_exists('validateRange'))
+{
+    function validateRange(?int $beginIndex, ?int $count)
+    {
+        if (is_null($beginIndex) && is_null($count))
+        {
+            return;
+        }
+        if (!is_null($beginIndex) xor !is_null($count))
+        {
+            throw new InvalidArgumentError("Beginning index and count must be supplied together.");
+        }
+        if ($beginIndex < 0)
+        {
+            throw new InvalidArgumentError("Beginning index and count must be a positive integer.");
+        }
+        if ($count <= 0)
+        {
+            throw new InvalidArgumentError("Count must be greater than zero.");
+        }
+    }
+}

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -710,7 +710,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals(4, $response->asSuccess()->length());
 
         $response = $this->client->listErase($this->TEST_CACHE_NAME, $listName);
-        $this->assertNotEmpty($response->asSuccess());
+        $this->assertNotNull($response->asSuccess());
 
         $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
         $this->assertNotNull($response->asSuccess());
@@ -733,7 +733,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals(4, $response->asSuccess()->length());
 
         $response = $this->client->listErase($this->TEST_CACHE_NAME, $listName, 0, 2);
-        $this->assertNotEmpty($response->asSuccess());
+        $this->assertNotNull($response->asSuccess());
 
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNotNull($response->asHit());
@@ -766,6 +766,6 @@ class CacheClientTest extends TestCase
     public function testListErase_MissingList()
     {
         $response = $this->client->listErase($this->TEST_CACHE_NAME, uniqid());
-        $this->assertNotEmpty($response->asSuccess());
+        $this->assertNotNull($response->asSuccess());
     }
 }

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -756,7 +756,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals(4, $response->asSuccess()->length());
 
         $response = $this->client->listErase($this->TEST_CACHE_NAME, $listName, 1, 20);
-        $this->assertNotEmpty($response->asSuccess());
+        $this->assertNotNull($response->asSuccess());
 
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNotNull($response->asHit());

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -65,10 +65,12 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asSuccess());
         $response = $this->client->set($cacheName, $key, $value);
         $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(get_class($response) . ": key $key = $value", "$response");
         $response = $this->client->get($cacheName, $key);
         $this->assertNotNull($response->asHit());
         $response = $response->asHit();
         $this->assertEquals($response->value(), $value);
+        $this->assertEquals(get_class($response) . ": $value", "$response");
         $response = $this->client->get($this->TEST_CACHE_NAME, $key);
         $this->assertNotNull($response->asMiss());
         $response = $this->client->deleteCache($cacheName);
@@ -112,6 +114,7 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asError());
         $response = $response->asError();
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->errorCode());
+        $this->assertEquals(get_class($response) . ": {$response->message()}", "$response");
     }
 
     public function testCreateCacheNullName() {
@@ -185,6 +188,7 @@ class CacheClientTest extends TestCase
             $cacheNames = array_map(fn($i) => $i->name(), $caches);
             $this->assertContains($cacheName, $cacheNames);
             $this->assertEquals(null, $listCachesResp->nextToken());
+            $this->assertEquals(get_class($listCachesResp) . ": " . join(', ', $cacheNames), "$listCachesResp");
         } finally {
             $this->client->deleteCache($cacheName);
         }
@@ -192,9 +196,9 @@ class CacheClientTest extends TestCase
 
     public function testListCachesBadAuth() {
         $client = $this->getBadAuthTokenClient();
-        $respnse = $client->listCaches();
-        $this->assertNotNull($respnse->asError());
-        $this->assertEquals(MomentoErrorCode::AUTHENTICATION_ERROR, $respnse->asError()->errorCode());
+        $response = $client->listCaches();
+        $this->assertNotNull($response->asError());
+        $this->assertEquals(MomentoErrorCode::AUTHENTICATION_ERROR, $response->asError()->errorCode());
     }
 
     public function testListCachesNextToken() {
@@ -423,6 +427,32 @@ class CacheClientTest extends TestCase
         $this->assertCount(2, $response->asHit()->values());
     }
 
+    public function testListPushFront_TruncateList()
+    {
+        $listName = uniqid();
+        $value1 = uniqid();
+        $value2 = uniqid();
+        $value3 = uniqid();
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value1, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value3, false, truncateBackToSize: 2);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals([$value3, $value2], $response->asHit()->values());
+    }
+
+    public function testListPushFront_TruncateList_NegativeValue()
+    {
+        $listName = uniqid();
+        $value = uniqid();
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false, truncateBackToSize: -1);
+        $this->assertNotNull($response->asError());
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
     public function testListPushBackFetchHappyPath() {
         $listName = uniqid();
         $value = uniqid();
@@ -443,5 +473,276 @@ class CacheClientTest extends TestCase
         $values = $response->asHit()->values();
         $this->assertNotEmpty($values);
         $this->assertEquals([$value, $value2], $values);
+    }
+
+    public function testListPushBack_NoRefreshTtl()
+    {
+        $listName = uniqid();
+        $value = uniqid();
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, 5);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, 10);
+        $this->assertNotNull($response->asSuccess());
+        sleep(5);
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull(($response->asMiss()));
+    }
+
+    public function testListPushBack_RefreshTtl()
+    {
+        $listName = uniqid();
+        $value = uniqid();
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, 2);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, true, 10);
+        $this->assertNotNull($response->asSuccess());
+        sleep(2);
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertCount(2, $response->asHit()->values());
+    }
+
+    public function testListPushBack_TruncateList()
+    {
+        $listName = uniqid();
+        $value1 = uniqid();
+        $value2 = uniqid();
+        $value3 = uniqid();
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value1, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value3, false, truncateFrontToSize: 2);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals([$value2, $value3], $response->asHit()->values());
+    }
+
+    public function testListPushBack_TruncateList_NegativeValue()
+    {
+        $listName = uniqid();
+        $value = uniqid();
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, truncateFrontToSize: -1);
+        $this->assertNotNull($response->asError());
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
+    public function testListPopFront_MissHappyPath()
+    {
+        $listName = uniqid();
+        $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asMiss());
+    }
+
+    public function testListPopFront_HappyPath()
+    {
+        $listName = uniqid();
+        $values = [];
+        foreach (range(0, 3) as $i)
+        {
+            $val = uniqid();
+            $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            array_unshift($values, $val);
+        }
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($values, $response->asHit()->values());
+        while ($val = array_shift($values))
+        {
+            $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
+            $this->assertNotNull($response->asHit());
+            $this->assertEquals($val, $response->asHit()->value());
+            $this->assertEquals(get_class($response) . ": {$response->asHit()->value()}", "$response");
+        }
+    }
+
+    public function testListPopBack_MissHappyPath()
+    {
+        $listName = uniqid();
+        $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asMiss());
+    }
+
+    public function testListPopFront_EmptyList()
+    {
+        $listName = uniqid();
+        $value = uniqid();
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($value, $response->asHit()->value());
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(0, $response->asSuccess()->length());
+        $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asMiss());
+    }
+
+    public function testListPopBack_HappyPath()
+    {
+        $listName = uniqid();
+        $values = [];
+        foreach (range(0, 3) as $i)
+        {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            $values[] = $val;
+        }
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($values, $response->asHit()->values());
+        while ($val = array_pop($values))
+        {
+            $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
+            $this->assertNotNull($response->asHit());
+            $this->assertEquals($val, $response->asHit()->value());
+            $this->assertEquals(get_class($response) . ": {$response->asHit()->value()}", "$response");
+        }
+    }
+
+    public function testListPopBack_EmptyList()
+    {
+        $listName = uniqid();
+        $value = uniqid();
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($value, $response->asHit()->value());
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(0, $response->asSuccess()->length());
+        $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asMiss());
+    }
+
+    public function testListRemoveValue_HappyPath()
+    {
+        $listName = uniqid();
+        $values = [];
+        $valueToRemove = uniqid();
+        foreach (range(0, 3) as $i)
+        {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            $values[] = $val;
+        }
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, false);
+        $this->assertNotNull($response->asSuccess());
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $expectedValues = $values;
+        array_push($expectedValues, $valueToRemove, $valueToRemove);
+        $this->assertEquals($expectedValues, $response->asHit()->values());
+
+        $response = $this->client->listRemoveValue($this->TEST_CACHE_NAME, $listName, $valueToRemove);
+        $this->assertNotNull($response->asSuccess());
+
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($values, $response->asHit()->values());
+    }
+
+    public function testListRemoveValues_ValueNotPresent()
+    {
+        $listName = uniqid();
+        $values = [];
+        foreach (range(0, 3) as $i)
+        {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            $values[] = $val;
+        }
+
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($values, $response->asHit()->values());
+
+        $response = $this->client->listRemoveValue($this->TEST_CACHE_NAME, $listName, "i-am-not-in-the-list");
+        $this->assertNotNull($response->asSuccess());
+
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals($values, $response->asHit()->values());
+    }
+
+    public function testListLength_HappyPath()
+    {
+        $listName = uniqid();
+        foreach (range(0, 3) as $i) {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+            $this->assertNotNull($response->asSuccess());
+            $this->assertEquals($i + 1, $response->asSuccess()->length());
+            $this->assertEquals(get_class($response) . ": {$response->asSuccess()->length()}", "$response");
+        }
+    }
+
+    public function testListLength_MissingList()
+    {
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, uniqid());
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(0, $response->asSuccess()->length());
+    }
+
+    // List erase
+    public function testListEraseAll_HappyPath()
+    {
+        $listName = uniqid();
+        foreach (range(0, 3) as $i) {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+        }
+
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(4, $response->asSuccess()->length());
+
+        $response = $this->client->listErase($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotEmpty($response->asSuccess());
+
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(0, $response->asSuccess()->length());
+    }
+
+    public function testListEraseRange_HappyPath()
+    {
+        $listName = uniqid();
+        $values = [];
+        foreach (range(0, 3) as $i) {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            $values[] = $val;
+        }
+
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(4, $response->asSuccess()->length());
+
+        $response = $this->client->listErase($this->TEST_CACHE_NAME, $listName, 0, 2);
+        $this->assertNotEmpty($response->asSuccess());
+
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals(array_slice($values, 2), $response->asHit()->values());
+    }
+
+    public function testListErase_MissingList()
+    {
+        $response = $this->client->listErase($this->TEST_CACHE_NAME, uniqid());
+        $this->assertNotEmpty($response->asSuccess());
     }
 }

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -740,6 +740,29 @@ class CacheClientTest extends TestCase
         $this->assertEquals(array_slice($values, 2), $response->asHit()->values());
     }
 
+    public function testListEraseRange_LargeCountValue()
+    {
+        $listName = uniqid();
+        $values = [];
+        foreach (range(0, 3) as $i) {
+            $val = uniqid();
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $this->assertNotNull($response->asSuccess());
+            $values[] = $val;
+        }
+
+        $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asSuccess());
+        $this->assertEquals(4, $response->asSuccess()->length());
+
+        $response = $this->client->listErase($this->TEST_CACHE_NAME, $listName, 1, 20);
+        $this->assertNotEmpty($response->asSuccess());
+
+        $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
+        $this->assertNotNull($response->asHit());
+        $this->assertEquals([$values[0]], $response->asHit()->values());
+    }
+
     public function testListErase_MissingList()
     {
         $response = $this->client->listErase($this->TEST_CACHE_NAME, uniqid());


### PR DESCRIPTION
Adds the remaining list API operations: pop front, pop back, length, and erase. Also adds `__toString()` in the response base class and overrides the base implementation in the response subtypes that hold data.