### PR TITLE
feat: using strict types

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,7 @@ Momento Serverless Cache の PHP クライアント SDK：従来のキャッシ�
 ### 必要条件
 
 - Momento Auth Token が必要です。[Momento CLI](https://github.com/momentohq/momento-cli)を使って生成できます。
-- 少なくとも PHP 7
+- 少なくとも PHP 8.0
 - grpc PHP エクステンション。 インストール方法はこちらの[gRPC docs](https://github.com/grpc/grpc/blob/v1.46.3/src/php/README.md)を参考にしてください。
 
 **IDE に関する注意事項**: [PhpStorm](https://www.jetbrains.com/phpstorm/)や[Microsoft Visual Studio Code](https://code.visualstudio.com/)の様な PHP 開発をサポートできる IDE が必要となります。

--- a/README.template.md
+++ b/README.template.md
@@ -7,7 +7,7 @@ Japanese: [日本語](README.ja.md)
 ### Requirements
 
 - A Momento Auth Token is required, you can generate one using the [Momento CLI](https://github.com/momentohq/momento-cli)
-- At least PHP 7
+- At least PHP 8.0
 - The grpc PHP extension. See the [gRPC docs](https://github.com/grpc/grpc/blob/v1.46.3/src/php/README.md) section on installing the extension.
 
 **IDE Notes**: You'll most likely want to use an IDE that supports PHP development, such as [PhpStorm](https://www.jetbrains.com/phpstorm/) or [Microsoft Visual Studio Code](https://code.visualstudio.com/).

--- a/composer.json
+++ b/composer.json
@@ -1,39 +1,41 @@
 {
-    "name": "momentohq/client-sdk-php",
-    "type": "library",
-    "autoload": {
-        "psr-4": {
-            "Momento\\": "src/",
-            "Cache_client\\": "types/Cache_client/",
-            "Control_client\\": "types/Control_client/",
-            "Auth\\": "types/Auth/",
-            "GPBMetadata\\": "types/GPBMetadata"
-        },
-        "files": [
-            "src/Utilities/_DataValidation.php"
-        ],
-        "classmap": [
-            "src/Cache/CacheOperationTypes/CacheOperationTypes.php",
-            "src/Cache/Errors/Errors.php"
-        ]
+  "name": "momentohq/client-sdk-php",
+  "type": "library",
+  "autoload": {
+    "psr-4": {
+      "Momento\\": "src/",
+      "Cache_client\\": "types/Cache_client/",
+      "Control_client\\": "types/Control_client/",
+      "Auth\\": "types/Auth/",
+      "GPBMetadata\\": "types/GPBMetadata"
     },
-    "autoload-dev": {
-        "psr-4": { "Momento\\Tests\\": "tests/" }
-    },
-    "require": {
-        "php": ">=7.4",
-        "ext-grpc": "*",
-        "firebase/php-jwt": "^6.3",
-        "google/protobuf": "3.21.5",
-        "grpc/grpc": "1.42.0"
-    },
-    "require-dev": {
-        "composer/composer" : "^2.4.1",
-        "phpunit/phpunit": "^9.5.23"
-    },
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": "dist",
-        "sort-packages": true
+    "files": [
+      "src/Utilities/_DataValidation.php"
+    ],
+    "classmap": [
+      "src/Cache/CacheOperationTypes/CacheOperationTypes.php",
+      "src/Cache/Errors/Errors.php"
+    ]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Momento\\Tests\\": "tests/"
     }
+  },
+  "require": {
+    "php": ">=8.0",
+    "ext-grpc": "*",
+    "firebase/php-jwt": "^6.3",
+    "google/protobuf": "3.21.5",
+    "grpc/grpc": "1.42.0"
+  },
+  "require-dev": {
+    "composer/composer": "^2.4.1",
+    "phpunit/phpunit": "^9.5.23"
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true
+  }
 }

--- a/src/Auth/AuthUtils.php
+++ b/src/Auth/AuthUtils.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Auth;
 

--- a/src/Auth/EnvMomentoTokenProvider.php
+++ b/src/Auth/EnvMomentoTokenProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Auth;
 
@@ -16,7 +17,7 @@ class EnvMomentoTokenProvider implements ICredentialProvider
     public function __construct(string $envVariableName)
     {
         $authToken = getenv($envVariableName);
-        if (isNullOrEmpty($authToken)) {
+        if ($authToken === false || isNullOrEmpty($authToken)) {
             throw new InvalidArgumentError("Environment variable $envVariableName is empty or null.");
         }
         $payload = AuthUtils::parseAuthToken($authToken);

--- a/src/Auth/ICredentialProvider.php
+++ b/src/Auth/ICredentialProvider.php
@@ -1,9 +1,13 @@
 <?php
+declare(strict_types=1);
+
 namespace Momento\Auth;
 
 interface ICredentialProvider
 {
-    public function getAuthToken() : string;
-    public function getControlEndpoint() : string;
+    public function getAuthToken(): string;
+
+    public function getControlEndpoint(): string;
+
     public function getCacheEndpoint() : string;
 }

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Cache\CacheOperationTypes;
 

--- a/src/Cache/Errors/Errors.php
+++ b/src/Cache/Errors/Errors.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Cache\Errors;
 

--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Cache;
 

--- a/src/Cache/_ControlGrpcManager.php
+++ b/src/Cache/_ControlGrpcManager.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Cache;
 
@@ -7,21 +8,22 @@ use Grpc\ChannelCredentials;
 use Control_client\ScsControlClient;
 
 
-class _ControlGrpcManager {
+class _ControlGrpcManager
+{
 
     public ScsControlClient $client;
 
     public function __construct(string $authToken, string $endpoint)
     {
         $options = [
-            "update_metadata" => function($metadata) use ($authToken) {
+            "update_metadata" => function ($metadata) use ($authToken) {
                 $metadata["authorization"] = [$authToken];
                 $metadata["agent"] = ["php:0.1"];
                 return $metadata;
             }
         ];
 
-        $channel = new Channel($endpoint, ["credentials"=>ChannelCredentials::createSsl()]);
+        $channel = new Channel($endpoint, ["credentials" => ChannelCredentials::createSsl()]);
         $this->client = new ScsControlClient($endpoint, $options, $channel);
     }
 

--- a/src/Cache/_DataGrpcManager.php
+++ b/src/Cache/_DataGrpcManager.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 namespace Momento\Cache;
 
 use Cache_client\ScsClient;
@@ -13,14 +15,14 @@ class _DataGrpcManager
     public function __construct(string $authToken, string $endpoint)
     {
         $options = [
-            "update_metadata" => function($metadata) use ($authToken) {
+            "update_metadata" => function ($metadata) use ($authToken) {
                 $metadata["authorization"] = [$authToken];
                 $metadata["agent"] = ["php:0.1"];
                 return $metadata;
             }
         ];
 
-        $channel = new Channel($endpoint, ["credentials"=>ChannelCredentials::createSsl()]);
+        $channel = new Channel($endpoint, ["credentials" => ChannelCredentials::createSsl()]);
         $this->client = new ScsClient($endpoint, $options, $channel);
     }
 }

--- a/src/Cache/_ScsControlClient.php
+++ b/src/Cache/_ScsControlClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Cache;
 

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Cache;
 
@@ -110,10 +111,10 @@ use function Momento\Utilities\validateValueName;
 class _ScsDataClient
 {
 
-    private static int $DEFAULT_DEADLINE_SECONDS = 5;
-    private int $deadline_seconds;
-    // Used to convert deadline_seconds into microseconds for gRPC
-    private static int $TIMEOUT_MULTIPLIER = 1000000;
+    private static int $DEFAULT_DEADLINE_MILLISECONDS = 5000;
+    private int $deadline_milliseconds;
+    // Used to convert deadline_milliseconds into microseconds for gRPC
+    private static int $TIMEOUT_MULTIPLIER = 1000;
     private int $defaultTtlSeconds;
     private _DataGrpcManager $grpcManager;
     private int $timeout;
@@ -123,8 +124,8 @@ class _ScsDataClient
         validateTtl($defaultTtlSeconds);
         validateOperationTimeout($operationTimeoutMs);
         $this->defaultTtlSeconds = $defaultTtlSeconds;
-        $this->deadline_seconds = $operationTimeoutMs ? $operationTimeoutMs / 1000.0 : self::$DEFAULT_DEADLINE_SECONDS;
-        $this->timeout = $this->deadline_seconds * self::$TIMEOUT_MULTIPLIER;
+        $this->deadline_milliseconds = $operationTimeoutMs ? $operationTimeoutMs : self::$DEFAULT_DEADLINE_MILLISECONDS;
+        $this->timeout = $this->deadline_milliseconds * self::$TIMEOUT_MULTIPLIER;
         $this->grpcManager = new _DataGrpcManager($authToken, $endpoint);
     }
 

--- a/src/Utilities/_DataValidation.php
+++ b/src/Utilities/_DataValidation.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Utilities;
 

--- a/src/Utilities/_ErrorConverter.php
+++ b/src/Utilities/_ErrorConverter.php
@@ -1,6 +1,8 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Utilities;
+
 use Grpc;
 use Momento\Cache\Errors\AlreadyExistsError;
 use Momento\Cache\Errors\AuthenticationError;
@@ -18,7 +20,8 @@ use Momento\Cache\Errors\TimeoutError;
 use Momento\Cache\Errors\UnknownError;
 use Momento\Cache\Errors\UnknownServiceError;
 
-class _ErrorConverter {
+class _ErrorConverter
+{
 
     public static array $rpcToError = [
         Grpc\STATUS_INVALID_ARGUMENT => InvalidArgumentError::class,
@@ -39,7 +42,7 @@ class _ErrorConverter {
         Grpc\STATUS_DATA_LOSS => InternalServerError::class
     ];
 
-    public static function convert(int $status, string $details, ?array $metadata=null) : SdkError
+    public static function convert(int $status, string $details, ?array $metadata = null): SdkError
     {
         if (array_key_exists($status, self::$rpcToError)) {
             $class = self::$rpcToError[$status];

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Momento\Tests\Cache;
 
@@ -137,9 +138,8 @@ class CacheClientTest extends TestCase
 
     public function testCreateCacheBadName()
     {
-        $response = $this->client->createCache(1);
-        $this->assertNotNull($response->asError(), "Expected error but got: $response");
-        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+        $this->expectException(TypeError::class);
+        $this->client->createCache(1);
     }
 
     public function testCreateCacheBadAuth()


### PR DESCRIPTION
Adds `declare(strict_types=1)` to each file to enable strict typing throughout the SDK. Also bumps our minimum PHP version requirement to 8.0+ and cleans up the timeout calculation in the data client.

Addresses issue #41 