### PR TITLE
chore: prefix all value accessors with `value<type>`

### DIFF
--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -1012,7 +1012,7 @@ class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResp
         $ret = [];
         foreach ($this->responsesList as $response) {
             if ($response->asHit()) {
-                $ret[] = $response->asHit()->value();
+                $ret[] = $response->asHit()->valueString();
             }
             if ($response->asMiss()) {
                 $ret[] = null;

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -430,7 +430,7 @@ class CacheListFetchResponseHit extends CacheListFetchResponse
         }
     }
 
-    public function valuesString(): array
+    public function valuesArray(): array
     {
         return $this->values;
     }

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -284,7 +284,7 @@ class CacheSetResponseSuccess extends CacheSetResponse
         return $this->key;
     }
 
-    public function value(): string
+    public function valueString(): string
     {
         return $this->value;
     }
@@ -338,7 +338,7 @@ class CacheGetResponseHit extends CacheGetResponse
         $this->value = $grpcGetResponse->getCacheBody();
     }
 
-    public function value(): string
+    public function valueString(): string
     {
         return $this->value;
     }
@@ -430,7 +430,7 @@ class CacheListFetchResponseHit extends CacheListFetchResponse
         }
     }
 
-    public function values(): array
+    public function valuesString(): array
     {
         return $this->values;
     }
@@ -577,7 +577,7 @@ class CacheListPopFrontResponseHit extends CacheListPopFrontResponse
         $this->value = $response->getFound()->getFront();
     }
 
-    public function value(): string
+    public function valueString(): string
     {
         return $this->value;
     }
@@ -634,7 +634,7 @@ class CacheListPopBackResponseHit extends CacheListPopBackResponse
         $this->value = $response->getFound()->getBack();
     }
 
-    public function value(): string
+    public function valueString(): string
     {
         return $this->value;
     }
@@ -825,7 +825,7 @@ class CacheDictionaryGetResponseHit extends CacheDictionaryGetResponse
         }
     }
 
-    public function value(): string
+    public function valueString(): string
     {
         return $this->value;
     }
@@ -1007,7 +1007,7 @@ class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResp
         }
     }
 
-    public function values(): array
+    public function valuesArray(): array
     {
         $ret = [];
         foreach ($this->responsesList as $response) {
@@ -1063,12 +1063,12 @@ class CacheDictionaryIncrementResponseSuccess extends CacheDictionaryIncrementRe
         $this->value = $response->getValue();
     }
 
-    public function value(): int
+    public function valueInt(): int
     {
         return $this->value;
     }
 
-    public function string(): string
+    public function valueString(): string
     {
         return "{$this->value}";
     }
@@ -1208,7 +1208,7 @@ class CacheSetFetchResponseHit extends CacheSetFetchResponse
         }
     }
 
-    public function stringSet(): array
+    public function valueArray(): array
     {
         return $this->stringSet;
     }

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -17,7 +17,6 @@ use Cache_client\_SetFetchResponse;
 use Cache_client\_SetResponse;
 use Cache_client\ECacheResult;
 use Control_client\_ListCachesResponse;
-use Momento\Cache\Errors\MomentoErrorCode;
 use Momento\Cache\Errors\SdkError;
 use Momento\Cache\Errors\UnknownError;
 
@@ -1066,11 +1065,6 @@ class CacheDictionaryIncrementResponseSuccess extends CacheDictionaryIncrementRe
     public function valueInt(): int
     {
         return $this->value;
-    }
-
-    public function valueString(): string
-    {
-        return "{$this->value}";
     }
 
     public function __toString()

--- a/src/Cache/Psr16CacheClient.php
+++ b/src/Cache/Psr16CacheClient.php
@@ -118,7 +118,7 @@ class Psr16CacheClient implements CacheInterface
             return $default;
         }
         $hit = $response->asHit();
-        return unserialize($hit->value());
+        return unserialize($hit->valueString());
     }
 
     /**

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -500,7 +500,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->valuesString();
+        $values = $response->asHit()->valuesArray();
         $this->assertNotEmpty($values);
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
@@ -513,7 +513,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->valuesString();
+        $values = $response->asHit()->valuesArray();
         $this->assertNotEmpty($values);
         $this->assertEquals([$value2, $value], $values);
     }
@@ -552,7 +552,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertCount(2, $response->asHit()->valuesString());
+        $this->assertCount(2, $response->asHit()->valuesArray());
     }
 
     public function testListPushFront_TruncateList()
@@ -576,7 +576,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals([$value3, $value2], $response->asHit()->valuesString());
+        $this->assertEquals([$value3, $value2], $response->asHit()->valuesArray());
     }
 
     public function testListPushFront_TruncateList_NegativeValue()
@@ -601,7 +601,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->valuesString();
+        $values = $response->asHit()->valuesArray();
         $this->assertNotEmpty($values);
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
@@ -614,7 +614,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->valuesString();
+        $values = $response->asHit()->valuesArray();
         $this->assertNotEmpty($values);
         $this->assertEquals([$value, $value2], $values);
     }
@@ -653,7 +653,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertCount(2, $response->asHit()->valuesString());
+        $this->assertCount(2, $response->asHit()->valuesArray());
     }
 
     public function testListPushBack_TruncateList()
@@ -677,7 +677,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals([$value2, $value3], $response->asHit()->valuesString());
+        $this->assertEquals([$value2, $value3], $response->asHit()->valuesArray());
     }
 
     public function testListPushBack_TruncateList_NegativeValue()
@@ -711,7 +711,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->valuesString());
+        $this->assertEquals($values, $response->asHit()->valuesArray());
         while ($val = array_shift($values)) {
             $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
             $this->assertNull($response->asError());
@@ -766,7 +766,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->valuesString());
+        $this->assertEquals($values, $response->asHit()->valuesArray());
 
         while ($val = array_pop($values)) {
             $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
@@ -825,7 +825,7 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
         $expectedValues = $values;
         array_push($expectedValues, $valueToRemove, $valueToRemove);
-        $this->assertEquals($expectedValues, $response->asHit()->valuesString());
+        $this->assertEquals($expectedValues, $response->asHit()->valuesArray());
 
         $response = $this->client->listRemoveValue($this->TEST_CACHE_NAME, $listName, $valueToRemove);
         $this->assertNull($response->asError());
@@ -834,7 +834,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->valuesString());
+        $this->assertEquals($values, $response->asHit()->valuesArray());
     }
 
     public function testListRemoveValues_ValueNotPresent()
@@ -852,7 +852,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->valuesString());
+        $this->assertEquals($values, $response->asHit()->valuesArray());
 
         $response = $this->client->listRemoveValue($this->TEST_CACHE_NAME, $listName, "i-am-not-in-the-list");
         $this->assertNull($response->asError());
@@ -861,7 +861,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->valuesString());
+        $this->assertEquals($values, $response->asHit()->valuesArray());
     }
 
     public function testListLength_HappyPath()
@@ -939,7 +939,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals(array_slice($values, 2), $response->asHit()->valuesString());
+        $this->assertEquals(array_slice($values, 2), $response->asHit()->valuesArray());
     }
 
     public function testListEraseRange_LargeCountValue()
@@ -966,7 +966,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals([$values[0]], $response->asHit()->valuesString());
+        $this->assertEquals([$values[0]], $response->asHit()->valuesArray());
     }
 
     public function testListErase_MissingList()
@@ -1698,7 +1698,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertCount(3, $response->asHit()->valuesString());
+        $this->assertCount(3, $response->asHit()->valuesArray());
         $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
 

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -66,14 +66,14 @@ class CacheClientTest extends TestCase
         $response = $this->client->set($cacheName, $key, $value);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(get_class($response) . ": key $key = $value", "$response");
+        $this->assertEquals("$response", get_class($response) . ": key $key = $value");
 
         $response = $this->client->get($cacheName, $key);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
         $response = $response->asHit();
-        $this->assertEquals($response->value(), $value);
-        $this->assertEquals(get_class($response) . ": $value", "$response");
+        $this->assertEquals($response->valueString(), $value);
+        $this->assertEquals("$response", get_class($response) . ": $value");
 
         $response = $this->client->get($this->TEST_CACHE_NAME, $key);
         $this->assertNull($response->asError());
@@ -128,7 +128,7 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $response = $response->asError();
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->errorCode());
-        $this->assertEquals(get_class($response) . ": {$response->message()}", "$response");
+        $this->assertEquals("$response", get_class($response) . ": {$response->message()}");
     }
 
     public function testCreateCacheNullName()
@@ -220,7 +220,7 @@ class CacheClientTest extends TestCase
             $cacheNames = array_map(fn($i) => $i->name(), $caches);
             $this->assertContains($cacheName, $cacheNames);
             $this->assertEquals(null, $listCachesResponse->nextToken());
-            $this->assertEquals(get_class($listCachesResponse) . ": " . join(', ', $cacheNames), "$listCachesResponse");
+            $this->assertEquals("$listCachesResponse", get_class($listCachesResponse) . ": " . join(', ', $cacheNames));
         } finally {
             $response = $this->client->deleteCache($cacheName);
             $this->assertNull($response->asError());
@@ -250,14 +250,14 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $response = $response->asSuccess();
         $this->assertNotNull($response);
-        $this->assertEquals($value, $response->value());
+        $this->assertEquals($value, $response->valueString());
         $this->assertEquals($key, $response->key());
 
         $response = $this->client->get($this->TEST_CACHE_NAME, $key);
         $this->assertNull($response->asError());
         $response = $response->asHit();
         $this->assertNotNull($response);
-        $this->assertEquals($value, $response->value());
+        $this->assertEquals($value, $response->valueString());
     }
 
     public function testGetMiss()
@@ -481,7 +481,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->values();
+        $values = $response->asHit()->valuesString();
         $this->assertNotEmpty($values);
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
@@ -494,7 +494,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->values();
+        $values = $response->asHit()->valuesString();
         $this->assertNotEmpty($values);
         $this->assertEquals([$value2, $value], $values);
     }
@@ -533,7 +533,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertCount(2, $response->asHit()->values());
+        $this->assertCount(2, $response->asHit()->valuesString());
     }
 
     public function testListPushFront_TruncateList()
@@ -557,7 +557,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals([$value3, $value2], $response->asHit()->values());
+        $this->assertEquals([$value3, $value2], $response->asHit()->valuesString());
     }
 
     public function testListPushFront_TruncateList_NegativeValue()
@@ -582,7 +582,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->values();
+        $values = $response->asHit()->valuesString();
         $this->assertNotEmpty($values);
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
@@ -595,7 +595,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $values = $response->asHit()->values();
+        $values = $response->asHit()->valuesString();
         $this->assertNotEmpty($values);
         $this->assertEquals([$value, $value2], $values);
     }
@@ -634,7 +634,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertCount(2, $response->asHit()->values());
+        $this->assertCount(2, $response->asHit()->valuesString());
     }
 
     public function testListPushBack_TruncateList()
@@ -658,7 +658,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals([$value2, $value3], $response->asHit()->values());
+        $this->assertEquals([$value2, $value3], $response->asHit()->valuesString());
     }
 
     public function testListPushBack_TruncateList_NegativeValue()
@@ -682,7 +682,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $values = [];
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -692,13 +692,13 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->values());
+        $this->assertEquals($values, $response->asHit()->valuesString());
         while ($val = array_shift($values)) {
             $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-            $this->assertEquals($val, $response->asHit()->value());
-            $this->assertEquals(get_class($response) . ": {$response->asHit()->value()}", "$response");
+            $this->assertEquals($val, $response->asHit()->valueString());
+            $this->assertEquals("$response", get_class($response) . ": {$response->asHit()->valueString()}");
         }
     }
 
@@ -721,7 +721,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
 
         $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
@@ -737,7 +737,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $values = [];
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -747,14 +747,14 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->values());
+        $this->assertEquals($values, $response->asHit()->valuesString());
 
         while ($val = array_pop($values)) {
             $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-            $this->assertEquals($val, $response->asHit()->value());
-            $this->assertEquals(get_class($response) . ": {$response->asHit()->value()}", "$response");
+            $this->assertEquals($val, $response->asHit()->valueString());
+            $this->assertEquals("$response", get_class($response) . ": {$response->asHit()->valueString()}");
         }
     }
 
@@ -769,7 +769,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
 
         $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
@@ -786,7 +786,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         $values = [];
         $valueToRemove = uniqid();
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -806,7 +806,7 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
         $expectedValues = $values;
         array_push($expectedValues, $valueToRemove, $valueToRemove);
-        $this->assertEquals($expectedValues, $response->asHit()->values());
+        $this->assertEquals($expectedValues, $response->asHit()->valuesString());
 
         $response = $this->client->listRemoveValue($this->TEST_CACHE_NAME, $listName, $valueToRemove);
         $this->assertNull($response->asError());
@@ -815,14 +815,14 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->values());
+        $this->assertEquals($values, $response->asHit()->valuesString());
     }
 
     public function testListRemoveValues_ValueNotPresent()
     {
         $listName = uniqid();
         $values = [];
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -833,7 +833,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->values());
+        $this->assertEquals($values, $response->asHit()->valuesString());
 
         $response = $this->client->listRemoveValue($this->TEST_CACHE_NAME, $listName, "i-am-not-in-the-list");
         $this->assertNull($response->asError());
@@ -842,7 +842,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($values, $response->asHit()->values());
+        $this->assertEquals($values, $response->asHit()->valuesString());
     }
 
     public function testListLength_HappyPath()
@@ -858,7 +858,7 @@ class CacheClientTest extends TestCase
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $this->assertEquals($i + 1, $response->asSuccess()->length());
-            $this->assertEquals(get_class($response) . ": {$response->asSuccess()->length()}", "$response");
+            $this->assertEquals("$response", get_class($response) . ": {$response->asSuccess()->length()}");
         }
     }
 
@@ -874,7 +874,7 @@ class CacheClientTest extends TestCase
     public function testListEraseAll_HappyPath()
     {
         $listName = uniqid();
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -900,7 +900,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $values = [];
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -920,14 +920,14 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals(array_slice($values, 2), $response->asHit()->values());
+        $this->assertEquals(array_slice($values, 2), $response->asHit()->valuesString());
     }
 
     public function testListEraseRange_LargeCountValue()
     {
         $listName = uniqid();
         $values = [];
-        foreach (range(0, 3) as $i) {
+        foreach (range(0, 3) as $ignored) {
             $val = uniqid();
             $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
             $this->assertNull($response->asError());
@@ -947,7 +947,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals([$values[0]], $response->asHit()->values());
+        $this->assertEquals([$values[0]], $response->asHit()->valuesString());
     }
 
     public function testListErase_MissingList()
@@ -1061,7 +1061,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
     }
 
     public function testDictionaryDeleteEmptyCacheName_IsError()
@@ -1117,22 +1117,22 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(1, $response->asSuccess()->value());
+        $this->assertEquals(1, $response->asSuccess()->valueInt());
 
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 41);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(42, $response->asSuccess()->value());
+        $this->assertEquals(42, $response->asSuccess()->valueInt());
 
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, -1042);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(-1000, $response->asSuccess()->value());
+        $this->assertEquals(-1000, $response->asSuccess()->valueInt());
 
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals("-1000", $response->asHit()->value());
+        $this->assertEquals("-1000", $response->asHit()->valueString());
     }
 
     public function testDictionaryIncrement_RefreshTtl()
@@ -1151,7 +1151,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals(2, $response->asHit()->value());
+        $this->assertEquals("2", $response->asHit()->valueString());
     }
 
     public function testDictionaryIncrement_NoRefreshTtl()
@@ -1183,12 +1183,12 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 0);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(10, $response->asSuccess()->value());
+        $this->assertEquals(10, $response->asSuccess()->valueInt());
 
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 90);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(100, $response->asSuccess()->value());
+        $this->assertEquals(100, $response->asSuccess()->valueInt());
 
         $response = $this->client->dictionarySet($this->TEST_CACHE_NAME, $dictionaryName, $field, "0", false);
         $this->assertNull($response->asError());
@@ -1197,7 +1197,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 0);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals(0, $response->asSuccess()->value());
+        $this->assertEquals(0, $response->asSuccess()->valueInt());
     }
 
     public function testDictionaryIncrement_FailedPrecondition()
@@ -1450,12 +1450,12 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field1);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value1, $response->asHit()->value());
+        $this->assertEquals($value1, $response->asHit()->valueString());
 
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field2);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value2, $response->asHit()->value());
+        $this->assertEquals($value2, $response->asHit()->valueString());
     }
 
     public function testDictionarySetBatchRefreshTtl_HappyPath()
@@ -1476,7 +1476,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
     }
 
     public function testDictionarySetBatchNoRefreshTtl_HappyPath()
@@ -1504,7 +1504,7 @@ class CacheClientTest extends TestCase
     {
         $this->expectException(TypeError::class);
         $dictionaryName = null;
-        $this->client->dictionaryGetBatch($this->TEST_CACHE_NAME, $dictionaryName, uniqid());
+        $this->client->dictionaryGetBatch($this->TEST_CACHE_NAME, $dictionaryName, [uniqid()]);
     }
 
     public function testDictionaryGetBatchWithEmptyDictionaryName_IsError()
@@ -1554,7 +1554,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $values = [$value1, $value2, null];
-        $this->assertEquals($values, $response->asSuccess()->values());
+        $this->assertEquals($values, $response->asSuccess()->valuesArray());
     }
 
     public function testDictionaryGetBatchDictionaryMissing_HappyPath()
@@ -1567,7 +1567,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $values = [null, null, null];
-        $this->assertEquals($values, $response->asSuccess()->values());
+        $this->assertEquals($values, $response->asSuccess()->valuesArray());
     }
 
     // __toString() tests
@@ -1578,7 +1578,7 @@ class CacheClientTest extends TestCase
         $value = "a short value";
         $response = $this->client->set($this->TEST_CACHE_NAME, $key, $value);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": key $key = $value", "$response");
+        $this->assertEquals("$response", get_class($response) . ": key $key = $value");
     }
 
     public function testCacheSetToString_LongValues()
@@ -1600,7 +1600,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->get($this->TEST_CACHE_NAME, $key);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": $value", "$response");
+        $this->assertEquals("$response", get_class($response) . ": $value");
     }
 
     public function testCacheGetToString_LongValue()
@@ -1612,7 +1612,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->get($this->TEST_CACHE_NAME, $key);
         $this->assertNull($response->asError());
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
         $this->assertStringEndsWith("...", "$response");
     }
 
@@ -1625,7 +1625,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": $value", "$response");
+        $this->assertEquals("$response", get_class($response) . ": $value");
     }
 
     public function testCacheListPopFrontToString_LongValue()
@@ -1637,7 +1637,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
         $this->assertStringEndsWith("...", "$response");
     }
 
@@ -1650,7 +1650,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": $value", "$response");
+        $this->assertEquals("$response", get_class($response) . ": $value");
     }
 
     public function testCacheListPopBackToString_LongValue()
@@ -1662,7 +1662,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
         $this->assertStringEndsWith("...", "$response");
     }
 
@@ -1679,8 +1679,8 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertCount(3, $response->asHit()->values());
-        $this->assertEquals(get_class($response) . ": 3 items", "$response");
+        $this->assertCount(3, $response->asHit()->valuesString());
+        $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
 
     public function testCacheListPushFrontToString_HappyPath()
@@ -1689,13 +1689,13 @@ class CacheClientTest extends TestCase
         $value = uniqid();
         $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 1 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 1 items");
         $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 2 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 2 items");
         $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 3 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
 
     public function testCacheListPushBackToString_HappyPath()
@@ -1704,13 +1704,13 @@ class CacheClientTest extends TestCase
         $value = uniqid();
         $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 1 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 1 items");
         $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 2 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 2 items");
         $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 3 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
 
     public function testCacheListLengthToString_HappyPath()
@@ -1726,7 +1726,7 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 3", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 3");
     }
 
     public function testDictionaryGetToString_HappyPath()
@@ -1740,7 +1740,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals(get_class($response) . ": $value", "$response");
+        $this->assertEquals("$response", get_class($response) . ": $value");
     }
 
     public function testDictionaryGetToString_LongValue()
@@ -1754,7 +1754,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGet($this->TEST_CACHE_NAME, $dictionaryName, $field);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($value, $response->asHit()->value());
+        $this->assertEquals($value, $response->asHit()->valueString());
         $this->assertStringEndsWith("...", "$response");
     }
 
@@ -1770,7 +1770,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryFetch($this->TEST_CACHE_NAME, $dictionaryName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals(get_class($response) . ": 5 items", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 5 items");
     }
 
     public function testDictionaryIncrementToString_HappyPath()
@@ -1782,11 +1782,11 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 2", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 2");
 
         $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 10);
         $this->assertNull($response->asError());
-        $this->assertEquals(get_class($response) . ": 12", "$response");
+        $this->assertEquals("$response", get_class($response) . ": 12");
     }
 
     public function testSetAddWithNullCacheName_ThrowsException()
@@ -1875,7 +1875,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($element, $response->asHit()->stringSet()[0]);
+        $this->assertEquals($element, $response->asHit()->valueArray()[0]);
     }
 
     public function testSetAddSetFetch_NoRefreshTtl()
@@ -1912,6 +1912,6 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($element, $response->asHit()->stringSet()[0]);
+        $this->assertEquals($element, $response->asHit()->valueArray()[0]);
     }
 }


### PR DESCRIPTION
Updated all value accessors with `value<type>`. 
For example, `valueString` and `valueInt`. 

As commented [here](https://github.com/momentohq/client-sdk-php/issues/48#issuecomment-1311988727), I think we can close #48. (I'm mentioning it here since I was going to address this issue in this PR along with #47).

Closes #47 