### PR TITLE
chore:  add `fieldValueDictionary` accessor to `dictionaryGetBatch` 

### DIFF
--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -982,8 +982,8 @@ abstract class CacheDictionaryGetFieldsResponse extends ResponseBase
 
 class CacheDictionaryGetFieldsResponseSuccess extends CacheDictionaryGetFieldsResponse
 {
-    private array $responsesList = [];
-    private array $fieldValueDictionary = [];
+    private array $responses = [];
+    private array $valuesDictionary = [];
 
     public function __construct(_DictionaryGetResponse $responses = null, ?int $numRequested = null, ?array $fields = null)
     {
@@ -992,46 +992,37 @@ class CacheDictionaryGetFieldsResponseSuccess extends CacheDictionaryGetFieldsRe
             parent::__construct();
             foreach ($responses->getFound()->getItems() as $response) {
                 if ($response->getResult() == ECacheResult::Hit) {
-                    $this->responsesList[] = new CacheDictionaryGetFieldResponseHit(null, $response->getCacheBody());
-                    $this->fieldValueDictionary[$fields[$counter]] = $response->getCacheBody();
+                    $this->responses[] = new CacheDictionaryGetFieldResponseHit(null, $response->getCacheBody());
+                    $this->valuesDictionary[$fields[$counter]] = $response->getCacheBody();
                     $counter++;
                 }
                 if ($response->getResult() == ECacheResult::Miss) {
-                    $this->responsesList[] = new CacheDictionaryGetFieldResponseMiss();
+                    $this->responses[] = new CacheDictionaryGetFieldResponseMiss();
                 } else {
-                    $this->responsesList[] = new CacheDictionaryGetFieldResponseError(new UnknownError(strval($response->getResult())));
+                    $this->responses[] = new CacheDictionaryGetFieldResponseError(new UnknownError(strval($response->getResult())));
                 }
             }
         }
         if (is_null($responses) && !is_null($numRequested)) {
             foreach (range(0, $numRequested - 1) as $ignored) {
-                $this->responsesList[] = new CacheDictionaryGetFieldResponseMiss();
+                $this->responses[] = new CacheDictionaryGetFieldResponseMiss();
             }
         }
     }
 
-    public function valuesArray(): array
+    public function responses(): array
     {
-        $ret = [];
-        foreach ($this->responsesList as $response) {
-            if ($response->asHit()) {
-                $ret[] = $response->asHit()->valueString();
-            }
-            if ($response->asMiss()) {
-                $ret[] = null;
-            }
-        }
-        return $ret;
+        return $this->responses;
     }
 
-    public function fieldValueDictionary(): array
+    public function valuesDictionary(): array
     {
-        return $this->fieldValueDictionary;
+        return $this->valuesDictionary;
     }
 
     public function __toString()
     {
-        $numResponses = count($this->responsesList);
+        $numResponses = count($this->responses());
         return parent::__toString() . ": $numResponses responses";
     }
 }

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -995,8 +995,7 @@ class CacheDictionaryGetFieldsResponseSuccess extends CacheDictionaryGetFieldsRe
                     $this->responses[] = new CacheDictionaryGetFieldResponseHit(null, $response->getCacheBody());
                     $this->valuesDictionary[$fields[$counter]] = $response->getCacheBody();
                     $counter++;
-                }
-                if ($response->getResult() == ECacheResult::Miss) {
+                } else if ($response->getResult() == ECacheResult::Miss) {
                     $this->responses[] = new CacheDictionaryGetFieldResponseMiss();
                 } else {
                     $this->responses[] = new CacheDictionaryGetFieldResponseError(new UnknownError(strval($response->getResult())));

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -983,7 +983,7 @@ abstract class CacheDictionaryGetBatchResponse extends ResponseBase
 class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResponse
 {
     private array $responsesList = [];
-    private array $fieldsValuesList = [];
+    private array $fieldValueDictionary = [];
 
     public function __construct(_DictionaryGetResponse $responses = null, ?int $numRequested = null, ?array $fields = null)
     {
@@ -993,7 +993,7 @@ class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResp
             foreach ($responses->getFound()->getItems() as $response) {
                 if ($response->getResult() == ECacheResult::Hit) {
                     $this->responsesList[] = new CacheDictionaryGetResponseHit(null, $response->getCacheBody());
-                    $this->fieldsValuesList[$fields[$counter]] = $response->getCacheBody();
+                    $this->fieldValueDictionary[$fields[$counter]] = $response->getCacheBody();
                     $counter++;
                 }
                 if ($response->getResult() == ECacheResult::Miss) {
@@ -1024,9 +1024,9 @@ class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResp
         return $ret;
     }
 
-    public function fieldsValuesArray(): array
+    public function fieldValueDictionary(): array
     {
-        return $this->fieldsValuesList;
+        return $this->fieldValueDictionary;
     }
 
     public function __toString()

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -908,7 +908,7 @@ class CacheDictionaryFetchResponseHit extends CacheDictionaryFetchResponse
         parent::__construct();
         $items = $response->getFound()->getItems();
         foreach ($items as $item) {
-            $this->$valuesDictionary[$item->getField()] = $item->getValue();
+            $this->valuesDictionary[$item->getField()] = $item->getValue();
         }
     }
 

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -901,25 +901,25 @@ abstract class CacheDictionaryFetchResponse extends ResponseBase
 
 class CacheDictionaryFetchResponseHit extends CacheDictionaryFetchResponse
 {
-    private array $dictionary;
+    private array $fieldValueDictionary;
 
     public function __construct(_DictionaryFetchResponse $response)
     {
         parent::__construct();
         $items = $response->getFound()->getItems();
         foreach ($items as $item) {
-            $this->dictionary[$item->getField()] = $item->getValue();
+            $this->fieldValueDictionary[$item->getField()] = $item->getValue();
         }
     }
 
-    public function dictionary(): array
+    public function fieldValueDictionary(): array
     {
-        return $this->dictionary;
+        return $this->fieldValueDictionary;
     }
 
     public function __toString()
     {
-        $numItems = count($this->dictionary);
+        $numItems = count($this->fieldValueDictionary);
         return parent::__toString() . ": $numItems items";
     }
 }

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -996,13 +996,13 @@ class CacheDictionaryGetFieldsResponseHit extends CacheDictionaryGetFieldsRespon
 
     public function __construct(_DictionaryGetResponse $responses, ?array $fields = null)
     {
-        $counter = 0;
         parent::__construct();
+        $counter = 0;
         foreach ($responses->getFound()->getItems() as $response) {
             if ($response->getResult() == ECacheResult::Hit) {
                 $this->responses[] = new CacheDictionaryGetFieldResponseHit(null, $response->getCacheBody());
                 $this->valuesDictionary[$fields[$counter]] = $response->getCacheBody();
-            } else if ($response->getResult() == ECacheResult::Miss) {
+            } elseif ($response->getResult() == ECacheResult::Miss) {
                 $this->responses[] = new CacheDictionaryGetFieldResponseMiss();
             } else {
                 $this->responses[] = new CacheDictionaryGetFieldResponseError(new UnknownError(strval($response->getResult())));

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -983,14 +983,18 @@ abstract class CacheDictionaryGetBatchResponse extends ResponseBase
 class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResponse
 {
     private array $responsesList = [];
+    private array $fieldsValuesList = [];
 
-    public function __construct(_DictionaryGetResponse $responses = null, ?int $numRequested = null)
+    public function __construct(_DictionaryGetResponse $responses = null, ?int $numRequested = null, ?array $fields = null)
     {
         if (!is_null($responses) && is_null($numRequested)) {
+            $counter = 0;
             parent::__construct();
             foreach ($responses->getFound()->getItems() as $response) {
                 if ($response->getResult() == ECacheResult::Hit) {
                     $this->responsesList[] = new CacheDictionaryGetResponseHit(null, $response->getCacheBody());
+                    $this->fieldsValuesList[$fields[$counter]] = $response->getCacheBody();
+                    $counter++;
                 }
                 if ($response->getResult() == ECacheResult::Miss) {
                     $this->responsesList[] = new CacheDictionaryGetResponseMiss();
@@ -1018,6 +1022,11 @@ class CacheDictionaryGetBatchResponseSuccess extends CacheDictionaryGetBatchResp
             }
         }
         return $ret;
+    }
+
+    public function fieldsValuesArray(): array
+    {
+        return $this->fieldsValuesList;
     }
 
     public function __toString()

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -1002,12 +1002,12 @@ class CacheDictionaryGetFieldsResponseHit extends CacheDictionaryGetFieldsRespon
             if ($response->getResult() == ECacheResult::Hit) {
                 $this->responses[] = new CacheDictionaryGetFieldResponseHit(null, $response->getCacheBody());
                 $this->valuesDictionary[$fields[$counter]] = $response->getCacheBody();
-                $counter++;
             } else if ($response->getResult() == ECacheResult::Miss) {
                 $this->responses[] = new CacheDictionaryGetFieldResponseMiss();
             } else {
                 $this->responses[] = new CacheDictionaryGetFieldResponseError(new UnknownError(strval($response->getResult())));
             }
+            $counter++;
         }
     }
 

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -901,25 +901,25 @@ abstract class CacheDictionaryFetchResponse extends ResponseBase
 
 class CacheDictionaryFetchResponseHit extends CacheDictionaryFetchResponse
 {
-    private array $fieldValueDictionary;
+    private array $valuesDictionary;
 
     public function __construct(_DictionaryFetchResponse $response)
     {
         parent::__construct();
         $items = $response->getFound()->getItems();
         foreach ($items as $item) {
-            $this->fieldValueDictionary[$item->getField()] = $item->getValue();
+            $this->$valuesDictionary[$item->getField()] = $item->getValue();
         }
     }
 
-    public function dictionary(): array
+    public function valuesDictionary(): array
     {
-        return $this->dictionary;
+        return $this->valuesDictionary;
     }
 
     public function __toString()
     {
-        $numItems = count($this->dictionary);
+        $numItems = count($this->valuesDictionary);
         return parent::__toString() . ": $numItems items";
     }
 }

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -576,7 +576,7 @@ class _ScsDataClient implements LoggerAwareInterface
             return new CacheDictionaryGetBatchResponseError(new UnknownError($e->getMessage()));
         }
         if ($dictionaryGetBatchResponse->hasFound()) {
-            return new CacheDictionaryGetBatchResponseSuccess($dictionaryGetBatchResponse);
+            return new CacheDictionaryGetBatchResponseSuccess($dictionaryGetBatchResponse, fields: $fields);
         }
         return new CacheDictionaryGetBatchResponseSuccess(null, count($fields));
     }

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -43,7 +43,8 @@ use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldResponseHit;
 use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldResponseMiss;
 use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldsResponse;
 use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldsResponseError;
-use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldsResponseSuccess;
+use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldsResponseHit;
+use Momento\Cache\CacheOperationTypes\CacheDictionaryGetFieldsResponseMiss;
 use Momento\Cache\CacheOperationTypes\CacheDictionaryIncrementResponse;
 use Momento\Cache\CacheOperationTypes\CacheDictionaryIncrementResponseError;
 use Momento\Cache\CacheOperationTypes\CacheDictionaryIncrementResponseSuccess;
@@ -576,9 +577,10 @@ class _ScsDataClient implements LoggerAwareInterface
             return new CacheDictionaryGetFieldsResponseError(new UnknownError($e->getMessage()));
         }
         if ($dictionaryGetFieldsResponse->hasFound()) {
-            return new CacheDictionaryGetFieldsResponseSuccess($dictionaryGetFieldsResponse, fields: $fields);
+            return new CacheDictionaryGetFieldsResponseHit($dictionaryGetFieldsResponse, fields: $fields);
         }
-        return new CacheDictionaryGetFieldsResponseSuccess(null, count($fields));
+        return new CacheDictionaryGetFieldsResponseMiss();
+
     }
 
     public function dictionaryIncrement(

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -472,22 +472,22 @@ class _ScsDataClient implements LoggerAwareInterface
             $dictionaryGetFieldRequest->setDictionaryName($dictionaryName);
             $dictionaryGetFieldRequest->setFields([$field]);
             $call = $this->grpcManager->client->DictionaryGet($dictionaryGetFieldRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
-            $dictionaryGetResponse = $this->processCall($call);
+            $dictionaryGetFieldResponse = $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheDictionaryGetFieldResponseError($e);
         } catch (Exception $e) {
             return new CacheDictionaryGetFieldResponseError(new UnknownError($e->getMessage()));
         }
-        if ($dictionaryGetResponse->hasMissing()) {
+        if ($dictionaryGetFieldResponse->hasMissing()) {
             return new CacheDictionaryGetFieldResponseMiss();
         }
-        if ($dictionaryGetResponse->getFound()->getItems()->count() == 0) {
+        if ($dictionaryGetFieldResponse->getFound()->getItems()->count() == 0) {
             return new CacheDictionaryGetFieldResponseError(new UnknownError("_DictionaryGetResponseResponse contained no data but was found"));
         }
-        if ($dictionaryGetResponse->getFound()->getItems()[0]->getResult() == ECacheResult::Miss) {
+        if ($dictionaryGetFieldResponse->getFound()->getItems()[0]->getResult() == ECacheResult::Miss) {
             return new CacheDictionaryGetFieldResponseMiss();
         }
-        return new CacheDictionaryGetFieldResponseHit($dictionaryGetResponse);
+        return new CacheDictionaryGetFieldResponseHit($dictionaryGetFieldResponse);
     }
 
     public function dictionaryDelete(string $cacheName, string $dictionaryName): CacheDictionaryDeleteResponse
@@ -529,7 +529,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryFetchResponseMiss();
     }
 
-    public function dictionarySetBatch(string $cacheName, string $dictionaryName, array $items, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
     {
         try {
             validateCacheName($cacheName);
@@ -569,14 +569,14 @@ class _ScsDataClient implements LoggerAwareInterface
             $dictionaryGetFieldsRequest->setDictionaryName($dictionaryName);
             $dictionaryGetFieldsRequest->setFields($fields);
             $call = $this->grpcManager->client->DictionaryGet($dictionaryGetFieldsRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
-            $dictionaryGetBatchResponse = $this->processCall($call);
+            $dictionaryGetFieldsResponse = $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheDictionaryGetFieldsResponseError($e);
         } catch (Exception $e) {
             return new CacheDictionaryGetFieldsResponseError(new UnknownError($e->getMessage()));
         }
-        if ($dictionaryGetBatchResponse->hasFound()) {
-            return new CacheDictionaryGetFieldsResponseSuccess($dictionaryGetBatchResponse, fields: $fields);
+        if ($dictionaryGetFieldsResponse->hasFound()) {
+            return new CacheDictionaryGetFieldsResponseSuccess($dictionaryGetFieldsResponse, fields: $fields);
         }
         return new CacheDictionaryGetFieldsResponseSuccess(null, count($fields));
     }

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -439,12 +439,12 @@ class _ScsDataClient implements LoggerAwareInterface
             validateValueName($value);
             $ttlMillis = $this->ttlToMillis($ttlSeconds);
             validateTtl($ttlMillis);
-            $dictionarySetRequest = new _DictionarySetRequest();
-            $dictionarySetRequest->setDictionaryName($dictionaryName);
-            $dictionarySetRequest->setItems([$this->toSingletonFieldValuePair($field, $value)]);
-            $dictionarySetRequest->setRefreshTtl($refreshTtl);
-            $dictionarySetRequest->setTtlMilliseconds($ttlMillis);
-            $call = $this->grpcManager->client->DictionarySet($dictionarySetRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
+            $dictionarySetFieldRequest = new _DictionarySetRequest();
+            $dictionarySetFieldRequest->setDictionaryName($dictionaryName);
+            $dictionarySetFieldRequest->setItems([$this->toSingletonFieldValuePair($field, $value)]);
+            $dictionarySetFieldRequest->setRefreshTtl($refreshTtl);
+            $dictionarySetFieldRequest->setTtlMilliseconds($ttlMillis);
+            $call = $this->grpcManager->client->DictionarySet($dictionarySetFieldRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
             $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheDictionarySetFieldResponseError($e);
@@ -468,10 +468,10 @@ class _ScsDataClient implements LoggerAwareInterface
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
             validateFieldName($field);
-            $dictionaryGetRequest = new _DictionaryGetRequest();
-            $dictionaryGetRequest->setDictionaryName($dictionaryName);
-            $dictionaryGetRequest->setFields([$field]);
-            $call = $this->grpcManager->client->DictionaryGet($dictionaryGetRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
+            $dictionaryGetFieldRequest = new _DictionaryGetRequest();
+            $dictionaryGetFieldRequest->setDictionaryName($dictionaryName);
+            $dictionaryGetFieldRequest->setFields([$field]);
+            $call = $this->grpcManager->client->DictionaryGet($dictionaryGetFieldRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
             $dictionaryGetResponse = $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheDictionaryGetFieldResponseError($e);
@@ -529,7 +529,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryFetchResponseMiss();
     }
 
-    public function dictionarySetBatch(string $cacheName, string $dictionaryName, array $items, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetBatchResponse
+    public function dictionarySetBatch(string $cacheName, string $dictionaryName, array $items, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
     {
         try {
             validateCacheName($cacheName);
@@ -544,12 +544,12 @@ class _ScsDataClient implements LoggerAwareInterface
                 $fieldValuePair->setValue($value);
                 $protoItems[] = $fieldValuePair;
             }
-            $dictionarySetBatchRequest = new _DictionarySetRequest();
-            $dictionarySetBatchRequest->setDictionaryName($dictionaryName);
-            $dictionarySetBatchRequest->setRefreshTtl($refreshTtl);
-            $dictionarySetBatchRequest->setItems($protoItems);
-            $dictionarySetBatchRequest->setTtlMilliseconds($ttlMillis);
-            $call = $this->grpcManager->client->DictionarySet($dictionarySetBatchRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
+            $dictionarySetFieldsRequest = new _DictionarySetRequest();
+            $dictionarySetFieldsRequest->setDictionaryName($dictionaryName);
+            $dictionarySetFieldsRequest->setRefreshTtl($refreshTtl);
+            $dictionarySetFieldsRequest->setItems($protoItems);
+            $dictionarySetFieldsRequest->setTtlMilliseconds($ttlMillis);
+            $call = $this->grpcManager->client->DictionarySet($dictionarySetFieldsRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
             $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheDictionarySetFieldsResponseError($e);
@@ -565,10 +565,10 @@ class _ScsDataClient implements LoggerAwareInterface
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
             validateItems($fields);
-            $dictionaryGetBatchRequest = new _DictionaryGetRequest();
-            $dictionaryGetBatchRequest->setDictionaryName($dictionaryName);
-            $dictionaryGetBatchRequest->setFields($fields);
-            $call = $this->grpcManager->client->DictionaryGet($dictionaryGetBatchRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
+            $dictionaryGetFieldsRequest = new _DictionaryGetRequest();
+            $dictionaryGetFieldsRequest->setDictionaryName($dictionaryName);
+            $dictionaryGetFieldsRequest->setFields($fields);
+            $call = $this->grpcManager->client->DictionaryGet($dictionaryGetFieldsRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
             $dictionaryGetBatchResponse = $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheDictionaryGetFieldsResponseError($e);
@@ -664,12 +664,12 @@ class _ScsDataClient implements LoggerAwareInterface
             validateElement($element);
             $ttlMillis = $this->ttlToMillis($ttlSeconds);
             validateTtl($ttlMillis);
-            $setAddRequest = new _SetUnionRequest();
-            $setAddRequest->setSetName($setName);
-            $setAddRequest->setRefreshTtl($refreshTt);
-            $setAddRequest->setTtlMilliseconds($ttlMillis);
-            $setAddRequest->setElements([$element]);
-            $call = $this->grpcManager->client->SetUnion($setAddRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
+            $setAddElementRequest = new _SetUnionRequest();
+            $setAddElementRequest->setSetName($setName);
+            $setAddElementRequest->setRefreshTtl($refreshTt);
+            $setAddElementRequest->setTtlMilliseconds($ttlMillis);
+            $setAddElementRequest->setElements([$element]);
+            $call = $this->grpcManager->client->SetUnion($setAddElementRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
             $this->processCall($call);
         } catch (SdkError $e) {
             return new CacheSetAddElementResponseError($e);

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1573,9 +1573,9 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
         $this->assertNull($response->asError());
-        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
         $counter = 0;
-        foreach ($response->asSuccess()->responses() as $response) {
+        foreach ($response->asHit()->responses() as $response) {
             if ($counter == 2) {
                 $this->assertEquals(CacheDictionaryGetFieldResponseMiss::class, get_class($response));
             } else {
@@ -1601,8 +1601,8 @@ class CacheClientTest extends TestCase
 
         $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
         $this->assertNull($response->asError());
-        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $this->assertEquals($items, $response->asSuccess()->valuesDictionary());
+        $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
+        $this->assertEquals($items, $response->asHit()->valuesDictionary());
     }
 
     public function testDictionaryGetFieldsDictionaryMissing_HappyPath()
@@ -1613,8 +1613,8 @@ class CacheClientTest extends TestCase
         $field3 = uniqid();
         $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
         $this->assertNull($response->asError());
-        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        foreach ($response->asSuccess()->responses() as $response) {
+        $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
+        foreach ($response->asHit()->responses() as $response) {
             $this->assertEquals(CacheDictionaryGetFieldResponseMiss::class, $response);
         }
     }

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1576,6 +1576,27 @@ class CacheClientTest extends TestCase
         $this->assertEquals($values, $response->asSuccess()->valuesArray());
     }
 
+    public function testDictionaryGetBatchFieldsValuesArray_HappyPath()
+    {
+        $dictionaryName = uniqid();
+        $field1 = uniqid();
+        $field2 = uniqid();
+        $field3 = uniqid();
+        $value1 = uniqid();
+        $value2 = uniqid();
+        $value3 = uniqid();
+        $items = [$field1 => $value1, $field2 => $value2, $field3 => $value3];
+        $response = $this->client->dictionarySetBatch($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+
+        $response = $this->client->dictionaryGetBatch($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        $values = [$value1, $value2, $value3];
+        $this->assertEquals($values, $response->asSuccess()->fieldsValuesArray());
+    }
+
     public function testDictionaryGetBatchDictionaryMissing_HappyPath()
     {
         $dictionaryName = uniqid();

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1619,6 +1619,25 @@ class CacheClientTest extends TestCase
         }
     }
 
+    public function testDictionaryGetBatchFieldsValuesArray_MixedPath()
+    {
+        $dictionaryName = uniqid();
+        $field1 = "key1";
+        $field2 = "key2";
+        $field3 = "key3";
+        $value1 = "val1";
+        $value3 = "val3";
+        $items = [$field1 => $value1, $field3 => $value3];
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+
+        $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asHit(), "Expected a success but got: $response");
+        $this->assertEquals($items, $response->asHit()->valuesDictionary());
+    }
+
     // __toString() tests
 
     public function testCacheSetToString_HappyPath()

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1368,7 +1368,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryFetch($this->TEST_CACHE_NAME, $dictionaryName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($response->asHit()->dictionary(), $contentDictionary);
+        $this->assertEquals($response->asHit()->fieldValueDictionary(), $contentDictionary);
     }
 
     public function testDictionaryFetchDictionaryDoesNotExist_Noop()

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1573,7 +1573,10 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $values = [$value1, $value2, null];
-        $this->assertEquals($values, $response->asSuccess()->valuesArray());
+        $counter = 0;
+        foreach ($response->asSuccess() as $response) {
+            $this->assertEquals($values[$counter], $response->valueString());
+        }
     }
 
     public function testDictionaryGetBatchFieldsValuesArray_HappyPath()
@@ -1586,15 +1589,14 @@ class CacheClientTest extends TestCase
         $value2 = uniqid();
         $value3 = uniqid();
         $items = [$field1 => $value1, $field2 => $value2, $field3 => $value3];
-        $response = $this->client->dictionarySetBatch($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryGetBatch($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
+        $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $values = [$value1, $value2, $value3];
-        $this->assertEquals($values, $response->asSuccess()->fieldValueDictionary());
+        $this->assertEquals($items, $response->asSuccess()->valuesDictionary());
     }
 
     public function testDictionaryGetFieldsDictionaryMissing_HappyPath()
@@ -1606,8 +1608,9 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $values = [null, null, null];
-        $this->assertEquals($values, $response->asSuccess()->valuesArray());
+        foreach ($response->asSuccess() as $response) {
+            $this->assertNull($response->valueString());
+        }
     }
 
     // __toString() tests

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1594,7 +1594,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $values = [$value1, $value2, $value3];
-        $this->assertEquals($values, $response->asSuccess()->fieldsValuesArray());
+        $this->assertEquals($values, $response->asSuccess()->fieldValueDictionary());
     }
 
     public function testDictionaryGetBatchDictionaryMissing_HappyPath()

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1370,7 +1370,7 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionaryFetch($this->TEST_CACHE_NAME, $dictionaryName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        $this->assertEquals($response->asHit()->fieldValueDictionary(), $contentDictionary);
+        $this->assertEquals($response->asHit()->valuesDictionary(), $contentDictionary);
     }
 
     public function testDictionaryFetchDictionaryDoesNotExist_Noop()


### PR DESCRIPTION
Added `fieldValueDictionary` accessor to `dictionaryGetBatch` to return an array of field/value pairs.
Also, updated `dictionary` accessor to `fieldValueDictionary` for `dictionaryFetch` to be consistent with naming.
Corresponding tests are also updated.

Closes #53 