### PR TITLE
chore: add `setDelete`

### DIFF
--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -1255,3 +1255,31 @@ class CacheSetRemoveElementResponseError extends CacheSetRemoveElementResponse
 {
     use ErrorBody;
 }
+
+abstract class CacheSetDeleteResponse extends ResponseBase
+{
+    public function asSuccess(): CacheSetDeleteResponseSuccess|null
+    {
+        if ($this->isSuccess()) {
+            return $this;
+        }
+        return null;
+    }
+
+    public function asError(): CacheSetDeleteResponseError|null
+    {
+        if ($this->isError()) {
+            return $this;
+        }
+        return null;
+    }
+}
+
+class CacheSetDeleteResponseSuccess extends CacheSetDeleteResponse
+{
+}
+
+class CacheSetDeleteResponseError extends CacheSetDeleteResponse
+{
+    use ErrorBody;
+}

--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -23,6 +23,7 @@ use Momento\Cache\CacheOperationTypes\CacheListPushBackResponse;
 use Momento\Cache\CacheOperationTypes\CacheListPushFrontResponse;
 use Momento\Cache\CacheOperationTypes\CacheListRemoveValueResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetAddElementResponse;
+use Momento\Cache\CacheOperationTypes\CacheSetDeleteResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetFetchResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetRemoveElementResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetResponse;
@@ -199,8 +200,13 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->setFetch($cacheName, $setName);
     }
 
-    public function setRemoveElement(string $cacheName, string $setName, string $element): CacheSetRemoveElementResponse 
+    public function setRemoveElement(string $cacheName, string $setName, string $element): CacheSetRemoveElementResponse
     {
         return $this->dataClient->setRemoveElement($cacheName, $setName, $element);
+    }
+
+    public function setDelete(string $cacheName, string $setName): CacheSetDeleteResponse
+    {
+        return $this->dataClient->setDelete($cacheName, $setName);
     }
 }

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -23,6 +23,7 @@ use Cache_client\_ListRange;
 use Cache_client\_ListRemoveRequest;
 use Cache_client\_SetDifferenceRequest;
 use Cache_client\_SetDifferenceRequest\_Subtrahend;
+use Cache_client\_SetDifferenceRequest\_Subtrahend\_Identity;
 use Cache_client\_SetDifferenceRequest\_Subtrahend\_Set;
 use Cache_client\_SetFetchRequest;
 use Cache_client\_SetRequest;
@@ -97,6 +98,9 @@ use Momento\Cache\CacheOperationTypes\CacheListRemoveValueResponseSuccess;
 use Momento\Cache\CacheOperationTypes\CacheSetAddElementResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetAddElementResponseError;
 use Momento\Cache\CacheOperationTypes\CacheSetAddElementResponseSuccess;
+use Momento\Cache\CacheOperationTypes\CacheSetDeleteResponse;
+use Momento\Cache\CacheOperationTypes\CacheSetDeleteResponseError;
+use Momento\Cache\CacheOperationTypes\CacheSetDeleteResponseSuccess;
 use Momento\Cache\CacheOperationTypes\CacheSetFetchResponse;
 use Momento\Cache\CacheOperationTypes\CacheSetFetchResponseError;
 use Momento\Cache\CacheOperationTypes\CacheSetFetchResponseHit;
@@ -707,7 +711,8 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheSetFetchResponseMiss();
     }
 
-    public function setRemoveElement(string $cacheName, string $setName, string $element): CacheSetRemoveElementResponse {
+    public function setRemoveElement(string $cacheName, string $setName, string $element): CacheSetRemoveElementResponse
+    {
         try {
             validateCacheName($cacheName);
             validateSetName($setName);
@@ -727,5 +732,25 @@ class _ScsDataClient implements LoggerAwareInterface
             return new CacheSetRemoveElementResponseError(new UnknownError($e->getMessage()));
         }
         return new CacheSetRemoveElementResponseSuccess();
+    }
+
+    public function setDelete(string $cacheName, string $setName): CacheSetDeleteResponse
+    {
+        try {
+            validateCacheName($cacheName);
+            validateSetName($setName);
+            $setDeleteRequest = new _SetDifferenceRequest();
+            $setDeleteRequest->setSetName($setName);
+            $subtrahend = new _Subtrahend();
+            $subtrahend->setIdentity(new _Identity());
+            $setDeleteRequest->setSubtrahend($subtrahend);
+            $call = $this->grpcManager->client->SetDifference($setDeleteRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
+            $this->processCall($call);
+        } catch (SdkError $e) {
+            return new CacheSetDeleteResponseError($e);
+        } catch (Exception $e) {
+            return new CacheSetDeleteResponseError(new UnknownError($e->getMessage()));
+        }
+        return new CacheSetDeleteResponseSuccess();
     }
 }

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -2128,5 +2128,9 @@ class CacheClientTest extends TestCase
         $response = $this->client->setDelete($this->TEST_CACHE_NAME, $setName);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
+
+        $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asMiss(), "Expected a miss but got ${response}.");
     }
 }

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -2030,14 +2030,14 @@ class CacheClientTest extends TestCase
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
 
-    public function testSetRemoveElement_HappyPath() 
+    public function testSetRemoveElement_HappyPath()
     {
         $setName = uniqid();
         $element = uniqid();
         $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        
+
         $response = $this->client->setRemoveElement($this->TEST_CACHE_NAME, $setName, uniqid());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
@@ -2064,8 +2064,69 @@ class CacheClientTest extends TestCase
         $response = $this->client->setRemoveElement($this->TEST_CACHE_NAME, $setName, uniqid());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        
+
         $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
         $this->assertNotNull($response->asMiss(), "Expected a miss but got: $response");
+    }
+
+    public function testSetDeleteWithNullCacheName_ThrowsException()
+    {
+        $this->expectException(TypeError::class);
+        $setName = uniqid();
+        $this->client->setDelete(null, $setName);
+    }
+
+    public function testSetDeleteWithEmptyCacheName_IsError()
+    {
+        $setName = uniqid();
+        $response = $this->client->setDelete("", $setName);
+        $this->assertNotNull($response->asError(), "Expected error but got: $response");
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
+    public function testSetDeleteWithNullSetName_ThrowsException()
+    {
+        $this->expectException(TypeError::class);
+        $this->client->setDelete($this->TEST_CACHE_NAME, null);
+    }
+
+    public function testSetDeleteWithEmptySetName_IsError()
+    {
+        $response = $this->client->setDelete($this->TEST_CACHE_NAME, "");
+        $this->assertNotNull($response->asError(), "Expected error but got: $response");
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
+    public function testSetDelete_SetDoesNotExist_Noop()
+    {
+        $setName = uniqid();
+        $response = $this->client->setDelete($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
+        $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asMiss(), "Expected a miss but got ${response}.");
+    }
+
+    public function testSetDelete_SetExists_HappyPath()
+    {
+        $setName = uniqid();
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), false);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), false);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), false);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
+
+        $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asHit(), "Expected a hit but got ${response}.");
+
+        $response = $this->client->setDelete($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
     }
 }


### PR DESCRIPTION
Received feedback from @malandis on this PR to implement `flush` in `laravel-cache` that it'll give better performance to use `setDelete` after "batch" delete keys from a cache. ([link](https://github.com/momentohq/laravel-cache/pull/12#discussion_r1025902176))
With that, added `setDelete` and tests so it can be used in `laravel-cache` to address the feedback.

Closes #69 