### PR TITLE
style: Add an EditorConfig file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
I noticed [a recent PR had stray changes trimming trailing whitespace](https://github.com/momentohq/client-sdk-php/pull/70/files). This makes it a little harder to follow.

An [EditorConfig](https://editorconfig.org/) file specifies basic editor configuration for the project, like trimming trailing whitespace. [Most editors support it automatically](https://editorconfig.org/#pre-installed) and for the rest [there is a plugin](https://editorconfig.org/#download). It doesn't hurt, and avoids those little whitespace nits.