### PR TITLE
feat: make Dockerfile more general-purpose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Check out our SDK [requirements](https://github.com/momentohq/client-sdk-php#req
 You will likely need to run this only once:
 
 ```bash
-docker build --tag php-test .
+./dev-docker-build.sh
 ```
 
 ## Run Integration Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,3 @@ RUN cd /usr/local/bin && curl -sS https://getcomposer.org/installer | php
 RUN cd /usr/local/bin && mv composer.phar composer
 RUN pecl install grpc
 RUN docker-php-ext-enable grpc
-
-WORKDIR /app
-COPY . ./
-RUN composer install

--- a/dev-docker-build.sh
+++ b/dev-docker-build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+set -o pipefail
+
+docker build --tag momento-php-dev .

--- a/dev-run-integration-tests.sh
+++ b/dev-run-integration-tests.sh
@@ -20,5 +20,10 @@ else
     export TEST_CACHE_NAME=$TEST_CACHE_NAME
 fi
 
-export DOCKER_COMMAND="php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml"
-docker run -d -e TEST_AUTH_TOKEN="$TEST_AUTH_TOKEN" -e TEST_CACHE_NAME="$TEST_CACHE_NAME" php-test bash -c "$DOCKER_COMMAND"
+DOCKER_IMAGE_NAME=momento-php-dev
+
+DOCKER_BASE_COMMAND="docker run -it -v$(pwd):/app -w=/app"
+$DOCKER_BASE_COMMAND $DOCKER_IMAGE_NAME composer install
+$DOCKER_BASE_COMMAND -e TEST_AUTH_TOKEN="$TEST_AUTH_TOKEN" -e TEST_CACHE_NAME="$TEST_CACHE_NAME" \
+	$DOCKER_IMAGE_NAME php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,22 +4,27 @@
 
 - A Momento Auth Token is required, you can generate one using
   the [Momento CLI](https://github.com/momentohq/momento-cli)
+
+### Running via local PHP
+
+You will need:
+
 - At least PHP 8.0
   The gRPC PHP extension. See the [gRPC docs](https://github.com/grpc/grpc/blob/v1.46.3/src/php/README.md) section on
 - [Composer](https://getcomposer.org/doc/00-intro.md)
 
-## Running the examples
+Run `composer update` to install the prerequisites.
+
+### Running via docker
 
 The Docker way:
 
-```bash
-# You can reference php commands to run various examples below.
-export DOCKER_COMMAND="php example.php"
-docker build --tag php-example --build-arg token=<YOUR_AUTH_TOKEN> --build-arg cache_name=<YOUR_CACHE_NAME> ../
-docker run -d -w /app/examples -it php-test bash -c $DOCKER_COMMAND
-```
+- Make sure you have run the `dev-docker-build.sh` script in the parent directory, to build the Momento PHP development
+  image.
+- Run the `./dev-php-docker-shell.sh` script to get a bash shell in a docker container that has all of the PHP dependencies
+  necessary to run the examples.  You may then run any of the commands below inside of the shell.
 
-Run `composer update` to install the prerequisites.
+## Running the examples
 
 Set required environment variables:
 

--- a/examples/dev-php-docker-shell.sh
+++ b/examples/dev-php-docker-shell.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+set -o pipefail
+
+DOCKER_IMAGE_NAME=momento-php-dev
+
+DOCKER_BASE_COMMAND="docker run -it -v$(pwd):/examples -w=/examples"
+$DOCKER_BASE_COMMAND $DOCKER_IMAGE_NAME composer install
+$DOCKER_BASE_COMMAND $DOCKER_IMAGE_NAME bash
+

--- a/examples/dictionary-example.php
+++ b/examples/dictionary-example.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 require "vendor/autoload.php";
 
 use Momento\Auth\EnvMomentoTokenProvider;
+use Momento\Cache\Errors\InvalidArgumentError;
 use Momento\Cache\SimpleCacheClient;
 use Momento\Config\Configurations\Laptop;
 use Momento\Logging\StderrLoggerFactory;
 use Psr\Log\LoggerInterface;
+use function Momento\Utilities\isNullOrEmpty;
 
 $CACHE_NAME = getenv("CACHE_NAME");
 $DICTIONARY_NAME = "example-dictionary";
@@ -16,6 +18,9 @@ $VALUE = "MyValue";
 $ITEM_DEFAULT_TTL_SECONDS = 60;
 
 // Setup
+if ($CACHE_NAME === false || isNullOrEmpty($CACHE_NAME)) {
+    throw new InvalidArgumentError("Environment variable CACHE_NAME is empty or null.");
+}
 $authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
 
 $configuration = Laptop::latest()->withLoggerFactory(new StderrLoggerFactory());


### PR DESCRIPTION
This commit changes the Dockerfile so that we can use a bind mount
to mount the local dir, rather than having to copy all the files
into the image at build time.

This should allow us to re-use this docker image for other purposes;
in the near future we can push it to an ECR repo so that devs
don't have to build it locally at all.
