### PR TITLE
chore: make `$refreshTtl` optional and re-order arguments for list push and dictionary increment 

### DIFF
--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -32,6 +32,8 @@ use Momento\Cache\CacheOperationTypes\DeleteCacheResponse;
 use Momento\Cache\CacheOperationTypes\ListCachesResponse;
 use Momento\Config\IConfiguration;
 use Momento\Logging\ILoggerFactory;
+use Momento\Requests\CollectionTtl;
+use Momento\Requests\CollectionTtlFactory;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
@@ -105,17 +107,17 @@ class SimpleCacheClient implements LoggerAwareInterface
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
+        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, CollectionTtl $ttl = null
     ): CacheListPushFrontResponse
     {
-        return $this->dataClient->listPushFront($cacheName, $listName, $value, $truncateBackToSize, $refreshTtl, $ttlSeconds);
+        return $this->dataClient->listPushFront($cacheName, $listName, $value, $truncateBackToSize, $ttl);
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
+        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, CollectionTtl $ttl = null
     ): CacheListPushBackResponse
     {
-        return $this->dataClient->listPushBack($cacheName, $listName, $value, $truncateFrontToSize, $refreshTtl, $ttlSeconds);
+        return $this->dataClient->listPushBack($cacheName, $listName, $value, $truncateFrontToSize, $ttl);
     }
 
     public function listPopFront(string $cacheName, string $listName): CacheListPopFrontResponse
@@ -143,9 +145,9 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->listErase($cacheName, $listName, $beginIndex, $count);
     }
 
-    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldResponse
+    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, CollectionTtl $ttl = null): CacheDictionarySetFieldResponse
     {
-        return $this->dataClient->dictionarySetField($cacheName, $dictionaryName, $field, $value, $refreshTtl, $ttlSeconds);
+        return $this->dataClient->dictionarySetField($cacheName, $dictionaryName, $field, $value, $ttl);
     }
 
     public function dictionaryGetField(string $cacheName, string $dictionaryName, string $field): CacheDictionaryGetFieldResponse
@@ -163,9 +165,9 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->dictionaryFetch($cacheName, $dictionaryName);
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, CollectionTtl $ttl = null): CacheDictionarySetFieldsResponse
     {
-        return $this->dataClient->dictionarySetFields($cacheName, $dictionaryName, $items, $refreshTtl, $ttlSeconds);
+        return $this->dataClient->dictionarySetFields($cacheName, $dictionaryName, $items, $ttl);
     }
 
     public function dictionaryGetFields(string $cacheName, string $dictionaryName, array $fields): CacheDictionaryGetFieldsResponse
@@ -174,10 +176,10 @@ class SimpleCacheClient implements LoggerAwareInterface
     }
 
     public function dictionaryIncrement(
-        string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?bool $refreshTtl = true, ?int $ttlSeconds = null
+        string $cacheName, string $dictionaryName, string $field, int $amount = 1, CollectionTtl $ttl = null
     ): CacheDictionaryIncrementResponse
     {
-        return $this->dataClient->dictionaryIncrement($cacheName, $dictionaryName, $field, $amount, $refreshTtl, $ttlSeconds);
+        return $this->dataClient->dictionaryIncrement($cacheName, $dictionaryName, $field, $amount, $ttl);
     }
 
     public function dictionaryRemoveField(string $cacheName, string $dictionaryName, string $field): CacheDictionaryRemoveFieldResponse
@@ -190,9 +192,9 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->dictionaryRemoveFields($cacheName, $dictionaryName, $fields);
     }
 
-    public function setAddElement(string $cacheName, string $setName, string $element, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheSetAddElementResponse
+    public function setAddElement(string $cacheName, string $setName, string $element, CollectionTtl $ttl = null): CacheSetAddElementResponse
     {
-        return $this->dataClient->setAddElement($cacheName, $setName, $element, $refreshTtl, $ttlSeconds);
+        return $this->dataClient->setAddElement($cacheName, $setName, $element, $ttl);
     }
 
     public function setFetch(string $cacheName, string $setName): CacheSetFetchResponse

--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -105,17 +105,17 @@ class SimpleCacheClient implements LoggerAwareInterface
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string $value, bool $refreshTtl, ?int $ttlSeconds = null, ?int $truncateBackToSize = null
+        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
     ): CacheListPushFrontResponse
     {
-        return $this->dataClient->listPushFront($cacheName, $listName, $value, $refreshTtl, $truncateBackToSize, $ttlSeconds);
+        return $this->dataClient->listPushFront($cacheName, $listName, $value, $truncateBackToSize, $refreshTtl, $ttlSeconds);
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string $value, bool $refreshTtl, ?int $ttlSeconds = null, ?int $truncateFrontToSize = null
+        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
     ): CacheListPushBackResponse
     {
-        return $this->dataClient->listPushBack($cacheName, $listName, $value, $refreshTtl, $truncateFrontToSize, $ttlSeconds);
+        return $this->dataClient->listPushBack($cacheName, $listName, $value, $truncateFrontToSize, $refreshTtl, $ttlSeconds);
     }
 
     public function listPopFront(string $cacheName, string $listName): CacheListPopFrontResponse
@@ -143,7 +143,7 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->listErase($cacheName, $listName, $beginIndex, $count);
     }
 
-    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldResponse
+    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldResponse
     {
         return $this->dataClient->dictionarySetField($cacheName, $dictionaryName, $field, $value, $refreshTtl, $ttlSeconds);
     }
@@ -163,7 +163,7 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->dictionaryFetch($cacheName, $dictionaryName);
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
     {
         return $this->dataClient->dictionarySetFields($cacheName, $dictionaryName, $items, $refreshTtl, $ttlSeconds);
     }
@@ -174,10 +174,10 @@ class SimpleCacheClient implements LoggerAwareInterface
     }
 
     public function dictionaryIncrement(
-        string $cacheName, string $dictionaryName, string $field, bool $refreshTtl, int $amount = 1, ?int $ttlSeconds = null
+        string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?bool $refreshTtl = true, ?int $ttlSeconds = null
     ): CacheDictionaryIncrementResponse
     {
-        return $this->dataClient->dictionaryIncrement($cacheName, $dictionaryName, $field, $refreshTtl, $amount, $ttlSeconds);
+        return $this->dataClient->dictionaryIncrement($cacheName, $dictionaryName, $field, $amount, $refreshTtl, $ttlSeconds);
     }
 
     public function dictionaryRemoveField(string $cacheName, string $dictionaryName, string $field): CacheDictionaryRemoveFieldResponse
@@ -190,7 +190,7 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->dictionaryRemoveFields($cacheName, $dictionaryName, $fields);
     }
 
-    public function setAddElement(string $cacheName, string $setName, string $element, bool $refreshTtl, ?int $ttlSeconds = null): CacheSetAddElementResponse
+    public function setAddElement(string $cacheName, string $setName, string $element, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheSetAddElementResponse
     {
         return $this->dataClient->setAddElement($cacheName, $setName, $element, $refreshTtl, $ttlSeconds);
     }

--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -33,7 +33,6 @@ use Momento\Cache\CacheOperationTypes\ListCachesResponse;
 use Momento\Config\IConfiguration;
 use Momento\Logging\ILoggerFactory;
 use Momento\Requests\CollectionTtl;
-use Momento\Requests\CollectionTtlFactory;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 

--- a/src/Cache/SimpleCacheClient.php
+++ b/src/Cache/SimpleCacheClient.php
@@ -106,14 +106,14 @@ class SimpleCacheClient implements LoggerAwareInterface
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, CollectionTtl $ttl = null
+        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?CollectionTtl $ttl = null
     ): CacheListPushFrontResponse
     {
         return $this->dataClient->listPushFront($cacheName, $listName, $value, $truncateBackToSize, $ttl);
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, CollectionTtl $ttl = null
+        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?CollectionTtl $ttl = null
     ): CacheListPushBackResponse
     {
         return $this->dataClient->listPushBack($cacheName, $listName, $value, $truncateFrontToSize, $ttl);
@@ -144,7 +144,7 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->listErase($cacheName, $listName, $beginIndex, $count);
     }
 
-    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, CollectionTtl $ttl = null): CacheDictionarySetFieldResponse
+    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?CollectionTtl $ttl = null): CacheDictionarySetFieldResponse
     {
         return $this->dataClient->dictionarySetField($cacheName, $dictionaryName, $field, $value, $ttl);
     }
@@ -164,7 +164,7 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->dictionaryFetch($cacheName, $dictionaryName);
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, CollectionTtl $ttl = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?CollectionTtl $ttl = null): CacheDictionarySetFieldsResponse
     {
         return $this->dataClient->dictionarySetFields($cacheName, $dictionaryName, $items, $ttl);
     }
@@ -175,7 +175,7 @@ class SimpleCacheClient implements LoggerAwareInterface
     }
 
     public function dictionaryIncrement(
-        string $cacheName, string $dictionaryName, string $field, int $amount = 1, CollectionTtl $ttl = null
+        string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?CollectionTtl $ttl = null
     ): CacheDictionaryIncrementResponse
     {
         return $this->dataClient->dictionaryIncrement($cacheName, $dictionaryName, $field, $amount, $ttl);
@@ -191,7 +191,7 @@ class SimpleCacheClient implements LoggerAwareInterface
         return $this->dataClient->dictionaryRemoveFields($cacheName, $dictionaryName, $fields);
     }
 
-    public function setAddElement(string $cacheName, string $setName, string $element, CollectionTtl $ttl = null): CacheSetAddElementResponse
+    public function setAddElement(string $cacheName, string $setName, string $element, ?CollectionTtl $ttl = null): CacheSetAddElementResponse
     {
         return $this->dataClient->setAddElement($cacheName, $setName, $element, $ttl);
     }

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -177,7 +177,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return $ttl * 1000;
     }
 
-    private function returnCollectionTtl($ttl): CollectionTtl
+    private function returnCollectionTtl(?CollectionTtl $ttl): CollectionTtl
     {
         if (!$ttl) {
             return CollectionTtl::fromCacheTtl();

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -271,7 +271,7 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string $value, bool $refreshTtl, ?int $truncateBackToSize = null, ?int $ttlSeconds = null
+        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
     ): CacheListPushFrontResponse
     {
         try {
@@ -300,7 +300,7 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string $value, bool $refreshTtl, ?int $truncateFrontToSize = null, ?int $ttlSeconds = null
+        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
     ): CacheListPushBackResponse
     {
         try {
@@ -442,7 +442,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheListEraseResponseSuccess();
     }
 
-    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldResponse
+    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldResponse
     {
         try {
             validateCacheName($cacheName);
@@ -541,7 +541,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryFetchResponseMiss();
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, bool $refreshTtl, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
     {
         try {
             validateCacheName($cacheName);
@@ -595,7 +595,7 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function dictionaryIncrement(
-        string $cacheName, string $dictionaryName, string $field, bool $refreshTtl, int $amount = 1, ?int $ttlSeconds = null
+        string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?bool $refreshTtl = true, ?int $ttlSeconds = null
     ): CacheDictionaryIncrementResponse
     {
         try {
@@ -669,7 +669,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryRemoveFieldsResponseSuccess();
     }
 
-    public function setAddElement(string $cacheName, string $setName, string $element, bool $refreshTt, ?int $ttlSeconds = null): CacheSetAddElementResponse
+    public function setAddElement(string $cacheName, string $setName, string $element, ?bool $refreshTt = true, ?int $ttlSeconds = null): CacheSetAddElementResponse
     {
         try {
             validateCacheName($cacheName);

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -116,6 +116,8 @@ use Momento\Cache\Errors\InternalServerError;
 use Momento\Cache\Errors\SdkError;
 use Momento\Cache\Errors\UnknownError;
 use Momento\Config\IConfiguration;
+use Momento\Requests\CollectionTtl;
+use Momento\Requests\CollectionTtlFactory;
 use Momento\Utilities\_ErrorConverter;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
@@ -173,6 +175,14 @@ class _ScsDataClient implements LoggerAwareInterface
         }
         validateTtl($ttl);
         return $ttl * 1000;
+    }
+
+    private function returnCollectionTtl($ttl): CollectionTtl
+    {
+        if (!$ttl) {
+            return CollectionTtl::fromCacheTtl();
+        }
+        return $ttl;
     }
 
     private function processCall(UnaryCall $call): mixed
@@ -271,18 +281,19 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
+        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, CollectionTtl $ttl = null
     ): CacheListPushFrontResponse
     {
         try {
+            $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateListName($listName);
             validateTruncateSize($truncateBackToSize);
-            $ttlMillis = $this->ttlToMillis($ttlSeconds);
+            $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             $listPushFrontRequest = new _ListPushFrontRequest();
             $listPushFrontRequest->setListName($listName);
             $listPushFrontRequest->setValue($value);
-            $listPushFrontRequest->setRefreshTtl($refreshTtl);
+            $listPushFrontRequest->setRefreshTtl($collectionTtl->getRefreshTtl());
             $listPushFrontRequest->setTtlMilliseconds($ttlMillis);
             if (!is_null($truncateBackToSize)) {
                 $listPushFrontRequest->setTruncateBackToSize($truncateBackToSize);
@@ -300,18 +311,19 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?bool $refreshTtl = true, ?int $ttlSeconds = null
+        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, CollectionTtl $ttl = null
     ): CacheListPushBackResponse
     {
         try {
+            $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateListName($listName);
             validateTruncateSize($truncateFrontToSize);
-            $ttlMillis = $this->ttlToMillis($ttlSeconds);
+            $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             $listPushBackRequest = new _ListPushBackRequest();
             $listPushBackRequest->setListName($listName);
             $listPushBackRequest->setValue($value);
-            $listPushBackRequest->setRefreshTtl($refreshTtl);
+            $listPushBackRequest->setRefreshTtl($collectionTtl->getRefreshTtl());
             $listPushBackRequest->setTtlMilliseconds($ttlMillis);
             if (!is_null($truncateFrontToSize)) {
                 $listPushBackRequest->setTruncateFrontToSize($truncateFrontToSize);
@@ -442,19 +454,20 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheListEraseResponseSuccess();
     }
 
-    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldResponse
+    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, CollectionTtl $ttl = null): CacheDictionarySetFieldResponse
     {
         try {
+            $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
             validateFieldName($field);
             validateValueName($value);
-            $ttlMillis = $this->ttlToMillis($ttlSeconds);
+            $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             validateTtl($ttlMillis);
             $dictionarySetFieldRequest = new _DictionarySetRequest();
             $dictionarySetFieldRequest->setDictionaryName($dictionaryName);
             $dictionarySetFieldRequest->setItems([$this->toSingletonFieldValuePair($field, $value)]);
-            $dictionarySetFieldRequest->setRefreshTtl($refreshTtl);
+            $dictionarySetFieldRequest->setRefreshTtl($collectionTtl->getRefreshTtl());
             $dictionarySetFieldRequest->setTtlMilliseconds($ttlMillis);
             $call = $this->grpcManager->client->DictionarySet($dictionarySetFieldRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
             $this->processCall($call);
@@ -541,14 +554,15 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryFetchResponseMiss();
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?bool $refreshTtl = true, ?int $ttlSeconds = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, CollectionTtl $ttl = null): CacheDictionarySetFieldsResponse
     {
         try {
+            $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
             validateItems($items);
             validateFieldsKeys($items);
-            $ttlMillis = $this->ttlToMillis($ttlSeconds);
+            $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             $protoItems = [];
             foreach ($items as $field => $value) {
                 $fieldValuePair = new _DictionaryFieldValuePair();
@@ -558,7 +572,7 @@ class _ScsDataClient implements LoggerAwareInterface
             }
             $dictionarySetFieldsRequest = new _DictionarySetRequest();
             $dictionarySetFieldsRequest->setDictionaryName($dictionaryName);
-            $dictionarySetFieldsRequest->setRefreshTtl($refreshTtl);
+            $dictionarySetFieldsRequest->setRefreshTtl($collectionTtl->getRefreshTtl());
             $dictionarySetFieldsRequest->setItems($protoItems);
             $dictionarySetFieldsRequest->setTtlMilliseconds($ttlMillis);
             $call = $this->grpcManager->client->DictionarySet($dictionarySetFieldsRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);
@@ -595,21 +609,22 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function dictionaryIncrement(
-        string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?bool $refreshTtl = true, ?int $ttlSeconds = null
+        string $cacheName, string $dictionaryName, string $field, int $amount = 1, CollectionTtl $ttl = null
     ): CacheDictionaryIncrementResponse
     {
         try {
+            $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
             validateFieldName($field);
-            $ttlMillis = $this->ttlToMillis($ttlSeconds);
+            $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             validateTtl($ttlMillis);
             $dictionaryIncrementRequest = new _DictionaryIncrementRequest();
             $dictionaryIncrementRequest
                 ->setDictionaryName($dictionaryName)
                 ->setField($field)
                 ->setAmount($amount)
-                ->setRefreshTtl($refreshTtl)
+                ->setRefreshTtl($collectionTtl->getRefreshTtl())
                 ->setTtlMilliseconds($ttlMillis);
             $call = $this->grpcManager->client->DictionaryIncrement(
                 $dictionaryIncrementRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -684,17 +684,18 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryRemoveFieldsResponseSuccess();
     }
 
-    public function setAddElement(string $cacheName, string $setName, string $element, ?bool $refreshTt = true, ?int $ttlSeconds = null): CacheSetAddElementResponse
+    public function setAddElement(string $cacheName, string $setName, string $element, CollectionTtl $ttl = null): CacheSetAddElementResponse
     {
         try {
+            $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateSetName($setName);
             validateElement($element);
-            $ttlMillis = $this->ttlToMillis($ttlSeconds);
+            $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             validateTtl($ttlMillis);
             $setAddElementRequest = new _SetUnionRequest();
             $setAddElementRequest->setSetName($setName);
-            $setAddElementRequest->setRefreshTtl($refreshTt);
+            $setAddElementRequest->setRefreshTtl($collectionTtl->getRefreshTtl());
             $setAddElementRequest->setTtlMilliseconds($ttlMillis);
             $setAddElementRequest->setElements([$element]);
             $call = $this->grpcManager->client->SetUnion($setAddElementRequest, ["cache" => [$cacheName]], ["timeout" => $this->timeout]);

--- a/src/Cache/_ScsDataClient.php
+++ b/src/Cache/_ScsDataClient.php
@@ -281,7 +281,7 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function listPushFront(
-        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, CollectionTtl $ttl = null
+        string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?CollectionTtl $ttl = null
     ): CacheListPushFrontResponse
     {
         try {
@@ -311,7 +311,7 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function listPushBack(
-        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, CollectionTtl $ttl = null
+        string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?CollectionTtl $ttl = null
     ): CacheListPushBackResponse
     {
         try {
@@ -454,7 +454,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheListEraseResponseSuccess();
     }
 
-    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, CollectionTtl $ttl = null): CacheDictionarySetFieldResponse
+    public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?CollectionTtl $ttl = null): CacheDictionarySetFieldResponse
     {
         try {
             $collectionTtl = $this->returnCollectionTtl($ttl);
@@ -554,7 +554,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryFetchResponseMiss();
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, CollectionTtl $ttl = null): CacheDictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?CollectionTtl $ttl = null): CacheDictionarySetFieldsResponse
     {
         try {
             $collectionTtl = $this->returnCollectionTtl($ttl);
@@ -609,7 +609,7 @@ class _ScsDataClient implements LoggerAwareInterface
     }
 
     public function dictionaryIncrement(
-        string $cacheName, string $dictionaryName, string $field, int $amount = 1, CollectionTtl $ttl = null
+        string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?CollectionTtl $ttl = null
     ): CacheDictionaryIncrementResponse
     {
         try {
@@ -684,7 +684,7 @@ class _ScsDataClient implements LoggerAwareInterface
         return new CacheDictionaryRemoveFieldsResponseSuccess();
     }
 
-    public function setAddElement(string $cacheName, string $setName, string $element, CollectionTtl $ttl = null): CacheSetAddElementResponse
+    public function setAddElement(string $cacheName, string $setName, string $element, ?CollectionTtl $ttl = null): CacheSetAddElementResponse
     {
         try {
             $collectionTtl = $this->returnCollectionTtl($ttl);

--- a/src/Requests/CollectionTtl.php
+++ b/src/Requests/CollectionTtl.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Momento\Requests;
+
+class CollectionTtl
+{
+    private ?int $ttl;
+    private ?bool $refreshTtl;
+
+    public function __construct(?int $ttl = null, ?bool $refreshTtl = true)
+    {
+        $this->ttl = $ttl;
+        $this->refreshTtl = $refreshTtl;
+    }
+
+    public static function fromCacheTtl(): CollectionTtl
+    {
+        return new CollectionTtl(null, true);
+    }
+
+    public static function of(int $ttl): CollectionTtl
+    {
+        return new CollectionTtl($ttl);
+    }
+
+    public function getTtl(): int|null
+    {
+        return $this->ttl;
+    }
+
+    public function getRefreshTtl(): bool|null
+    {
+        return $this->refreshTtl;
+    }
+
+    public function withRefreshTtlOnUpdates(): CollectionTtl
+    {
+        return new CollectionTtl($this->ttl, $this->refreshTtl);
+    }
+
+    public function withNoRefreshTtlOnUpdates(): CollectionTtl
+    {
+        return new CollectionTtl($this->ttl, false);
+    }
+}

--- a/src/Requests/CollectionTtl.php
+++ b/src/Requests/CollectionTtl.php
@@ -5,12 +5,12 @@ namespace Momento\Requests;
 
 class CollectionTtl
 {
-    private ?int $ttl;
+    private ?int $ttlSeconds;
     private ?bool $refreshTtl;
 
-    public function __construct(?int $ttl = null, ?bool $refreshTtl = true)
+    public function __construct(?int $ttlSeconds = null, ?bool $refreshTtl = true)
     {
-        $this->ttl = $ttl;
+        $this->ttlSeconds = $ttlSeconds;
         $this->refreshTtl = $refreshTtl;
     }
 
@@ -26,7 +26,7 @@ class CollectionTtl
 
     public function getTtl(): int|null
     {
-        return $this->ttl;
+        return $this->ttlSeconds;
     }
 
     public function getRefreshTtl(): bool|null
@@ -36,11 +36,11 @@ class CollectionTtl
 
     public function withRefreshTtlOnUpdates(): CollectionTtl
     {
-        return new CollectionTtl($this->ttl, $this->refreshTtl);
+        return new CollectionTtl($this->ttlSeconds, $this->refreshTtl);
     }
 
     public function withNoRefreshTtlOnUpdates(): CollectionTtl
     {
-        return new CollectionTtl($this->ttl, false);
+        return new CollectionTtl($this->ttlSeconds, false);
     }
 }

--- a/src/Requests/CollectionTtl.php
+++ b/src/Requests/CollectionTtl.php
@@ -19,9 +19,9 @@ class CollectionTtl
         return new CollectionTtl(null, true);
     }
 
-    public static function of(int $ttl): CollectionTtl
+    public static function of(int $ttlSeconds): CollectionTtl
     {
-        return new CollectionTtl($ttl);
+        return new CollectionTtl($ttlSeconds);
     }
 
     public function getTtl(): int|null

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -995,7 +995,7 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1009,7 +1009,7 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1024,12 +1024,12 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false, 5);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(1);
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false, 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(4);

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1164,7 +1164,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 10);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);
@@ -1613,10 +1613,7 @@ class CacheClientTest extends TestCase
         $field3 = uniqid();
         $response = $this->client->dictionaryGetFields($this->TEST_CACHE_NAME, $dictionaryName, [$field1, $field2, $field3]);
         $this->assertNull($response->asError());
-        $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
-        foreach ($response->asHit()->responses() as $response) {
-            $this->assertEquals(CacheDictionaryGetFieldResponseMiss::class, $response);
-        }
+        $this->assertNotNull($response->asMiss(), "Expected a hit but got: $response");
     }
 
     public function testDictionaryGetBatchFieldsValuesArray_MixedPath()

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -16,7 +16,6 @@ use Momento\Config\Transport\StaticGrpcConfiguration;
 use Momento\Config\Transport\StaticTransportStrategy;
 use Momento\Logging\NullLoggerFactory;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\NullLogger;
 use RuntimeException;
 use TypeError;
 
@@ -495,7 +494,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         $value = uniqid();
         $value2 = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, true, 6000);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 6000);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(1, $response->asSuccess()->listLength());
@@ -508,7 +507,7 @@ class CacheClientTest extends TestCase
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, true, 6000);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, ttlSeconds: 6000);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(2, $response->asSuccess()->listLength());
@@ -525,11 +524,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false, 5);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 5);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false, 10);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -543,11 +542,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false, 2);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 2);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, true, 10);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -564,15 +563,15 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $value3 = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value1, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value1, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value3, false, truncateBackToSize: 2);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value3, 2, false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -586,7 +585,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false, truncateBackToSize: -1);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, -1, false);
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -596,7 +595,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         $value = uniqid();
         $value2 = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, true, 6000);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 6000);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(1, $response->asSuccess()->listLength());
@@ -609,7 +608,7 @@ class CacheClientTest extends TestCase
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, true, 6000);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, ttlSeconds: 6000);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(2, $response->asSuccess()->listLength());
@@ -626,11 +625,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, 5);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 5);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, 10);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -644,11 +643,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, 2);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 2);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, true, 10);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -665,15 +664,15 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $value3 = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value1, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value1, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value3, false, truncateFrontToSize: 2);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value3, 2, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -687,7 +686,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false, truncateFrontToSize: -1);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, -1, refreshTtl: false);
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -706,7 +705,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             array_unshift($values, $val);
@@ -736,7 +735,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -761,7 +760,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -784,7 +783,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -810,16 +809,16 @@ class CacheClientTest extends TestCase
         $valueToRemove = uniqid();
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
         }
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -846,7 +845,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -872,7 +871,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         foreach (range(0, 3) as $i) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -898,7 +897,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         }
@@ -924,7 +923,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -951,7 +950,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -1075,7 +1074,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, true, 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1127,7 +1126,7 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = "";
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false);
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1136,17 +1135,17 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(1, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 41);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 41, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(42, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, -1042);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: -1042, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(-1000, $response->asSuccess()->valueInt());
@@ -1161,11 +1160,11 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, ttlSeconds: 2);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false, ttlSeconds: 2);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, true, ttlSeconds: 10);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);
@@ -1180,11 +1179,11 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, ttlSeconds: 5);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false, ttlSeconds: 5);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, ttlSeconds: 10);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(6);
@@ -1202,12 +1201,12 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 0);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 0, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(10, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 90);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 90, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(100, $response->asSuccess()->valueInt());
@@ -1216,7 +1215,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 0);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 0, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(0, $response->asSuccess()->valueInt());
@@ -1230,7 +1229,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, true, 1);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 1);
         $this->assertNotNull($response->asError(), "Expected an error but got: $response");
         $this->assertEquals(MomentoErrorCode::FAILED_PRECONDITION_ERROR, $response->asError()->errorCode());
     }
@@ -1361,10 +1360,10 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $contentDictionary = [$field1 => $value1, $field2 => $value2];
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field1, $value1, true, 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field1, $value1, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field2, $value2, true, 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field2, $value2, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1490,7 +1489,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, true, 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);
@@ -1689,7 +1688,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = "a short value";
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
@@ -1701,7 +1700,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = str_repeat("a", 256);
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
@@ -1714,7 +1713,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = "a short value";
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
@@ -1726,7 +1725,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = str_repeat("a", 256);
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
@@ -1739,11 +1738,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
 
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
@@ -1756,13 +1755,13 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 1 items");
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 2 items");
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
@@ -1771,13 +1770,13 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 1 items");
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 2 items");
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
@@ -1786,11 +1785,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
         $this->assertNull($response->asError());
 
         $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
@@ -1849,11 +1848,11 @@ class CacheClientTest extends TestCase
         $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "1", false);
         $this->assertNull($response->asError());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 2");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, false, 10);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 10, refreshTtl: false);
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 12");
     }
@@ -1974,7 +1973,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, true, 10);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, ttlSeconds: 10);
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1199,7 +1199,7 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "10", false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "10", CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1213,7 +1213,7 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(100, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "0", false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "0", CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -15,6 +15,8 @@ use Momento\Config\IConfiguration;
 use Momento\Config\Transport\StaticGrpcConfiguration;
 use Momento\Config\Transport\StaticTransportStrategy;
 use Momento\Logging\NullLoggerFactory;
+use Momento\Requests\CollectionTtl;
+use Momento\Requests\CollectionTtlFactory;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 use TypeError;
@@ -494,7 +496,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         $value = uniqid();
         $value2 = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 6000);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(6000));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(1, $response->asSuccess()->listLength());
@@ -507,7 +509,7 @@ class CacheClientTest extends TestCase
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, ttlSeconds: 6000);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, ttl: CollectionTtl::of(6000));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(2, $response->asSuccess()->listLength());
@@ -524,11 +526,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 5);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 10);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -542,11 +544,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 2);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 10);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(10)->withRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -563,15 +565,15 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $value3 = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value1, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value1, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value2, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value3, 2, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value3, 2, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -585,7 +587,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, -1, false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, -1, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -595,7 +597,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         $value = uniqid();
         $value2 = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 6000);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(6000));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(1, $response->asSuccess()->listLength());
@@ -608,7 +610,7 @@ class CacheClientTest extends TestCase
         $this->assertCount(1, $values);
         $this->assertContains($value, $values);
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, ttlSeconds: 6000);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, ttl: CollectionTtl::of(6000));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(2, $response->asSuccess()->listLength());
@@ -625,11 +627,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 5);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 10);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -643,11 +645,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false, ttlSeconds: 2);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttlSeconds: 10);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -664,15 +666,15 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $value3 = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value1, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value1, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value2, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value3, 2, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value3, 2, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -686,7 +688,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, -1, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, -1, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -705,7 +707,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             array_unshift($values, $val);
@@ -735,7 +737,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -760,7 +762,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -783,7 +785,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -809,16 +811,16 @@ class CacheClientTest extends TestCase
         $valueToRemove = uniqid();
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
         }
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $valueToRemove, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -845,7 +847,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -871,7 +873,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         foreach (range(0, 3) as $i) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -897,7 +899,7 @@ class CacheClientTest extends TestCase
         $listName = uniqid();
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         }
@@ -923,7 +925,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -950,7 +952,7 @@ class CacheClientTest extends TestCase
         $values = [];
         foreach (range(0, 3) as $ignored) {
             $val = uniqid();
-            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, refreshTtl: false);
+            $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $val, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
             $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
             $values[] = $val;
@@ -1060,7 +1062,7 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = "";
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1070,11 +1072,11 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false, 2);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, ttl: CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, ttlSeconds: 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, ttl: CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1106,7 +1108,7 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, uniqid(), ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1126,7 +1128,7 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = "";
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1135,17 +1137,17 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(1, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 41, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 41, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(42, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: -1042, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: -1042, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(-1000, $response->asSuccess()->valueInt());
@@ -1160,11 +1162,11 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false, ttlSeconds: 2);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttlSeconds: 10);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);
@@ -1179,11 +1181,11 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false, ttlSeconds: 5);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false, ttlSeconds: 10);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(6);
@@ -1201,12 +1203,12 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 0, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 0, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(10, $response->asSuccess()->valueInt());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 90, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 90, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(100, $response->asSuccess()->valueInt());
@@ -1215,7 +1217,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 0, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 0, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         $this->assertEquals(0, $response->asSuccess()->valueInt());
@@ -1225,7 +1227,7 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "amcaface", false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "amcaface", CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1260,7 +1262,7 @@ class CacheClientTest extends TestCase
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asMiss(), "Expected a miss but got: $response");
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field1, $value1, false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field1, $value1, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1306,11 +1308,11 @@ class CacheClientTest extends TestCase
         $fields = [uniqid(), uniqid()];
         $otherField = uniqid();
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $fields[0], uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $fields[0], uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $fields[1], uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $fields[1], uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $otherField, uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $otherField, uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->dictionaryRemoveFields($this->TEST_CACHE_NAME, $dictionaryName, $fields);
@@ -1360,10 +1362,10 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $contentDictionary = [$field1 => $value1, $field2 => $value2];
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field1, $value1, ttlSeconds: 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field1, $value1, CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field2, $value2, ttlSeconds: 10);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field2, $value2, CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1392,15 +1394,15 @@ class CacheClientTest extends TestCase
     public function testDictionaryDeleteDictionaryExists_HappyPath()
     {
         $dictionaryName = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, uniqid(), uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, uniqid(), uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, uniqid(), uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, uniqid(), uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, uniqid(), uniqid(), false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, uniqid(), uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1422,14 +1424,14 @@ class CacheClientTest extends TestCase
         $this->expectException(TypeError::class);
         $dictionaryName = null;
         $items = [uniqid()];
-        $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false);
+        $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
     }
 
     public function testDictionarySetFieldsWithEmptyDictionaryName_IsError()
     {
         $dictionaryName = "";
         $items = [uniqid()];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1439,19 +1441,19 @@ class CacheClientTest extends TestCase
         $this->expectException(TypeError::class);
         $dictionaryName = uniqid();
         $items = null;
-        $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false);
+        $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
     }
 
     public function testDictionarySetFieldsWithEmptyItems_IsError()
     {
         $dictionaryName = uniqid();
         $items = [""];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
 
         $items = [];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1464,7 +1466,7 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $items = [$field1 => $value1, $field2 => $value2];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1485,11 +1487,11 @@ class CacheClientTest extends TestCase
         $field = uniqid();
         $value = uniqid();
         $content = [$field => $value];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, false, 2);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, ttlSeconds: 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);
@@ -1506,12 +1508,12 @@ class CacheClientTest extends TestCase
         $field = uniqid();
         $value = uniqid();
         $content = [$field => $value];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, false, 5);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(1);
 
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, false, 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $content, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(4);
@@ -1567,7 +1569,7 @@ class CacheClientTest extends TestCase
         $value1 = uniqid();
         $value2 = uniqid();
         $items = [$field1 => $value1, $field2 => $value2];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 600);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::of(600)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1595,7 +1597,7 @@ class CacheClientTest extends TestCase
         $value2 = uniqid();
         $value3 = uniqid();
         $items = [$field1 => $value1, $field2 => $value2, $field3 => $value3];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1625,7 +1627,7 @@ class CacheClientTest extends TestCase
         $value1 = "val1";
         $value3 = "val3";
         $items = [$field1 => $value1, $field3 => $value3];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, false, 10);
+        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1685,7 +1687,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = "a short value";
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
@@ -1697,7 +1699,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = str_repeat("a", 256);
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopFront($this->TEST_CACHE_NAME, $listName);
@@ -1710,7 +1712,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = "a short value";
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
@@ -1722,7 +1724,7 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = str_repeat("a", 256);
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->listPopBack($this->TEST_CACHE_NAME, $listName);
@@ -1735,11 +1737,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->listFetch($this->TEST_CACHE_NAME, $listName);
@@ -1752,13 +1754,13 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 1 items");
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 2 items");
-        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushFront($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
@@ -1767,13 +1769,13 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 1 items");
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 2 items");
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 3 items");
     }
@@ -1782,11 +1784,11 @@ class CacheClientTest extends TestCase
     {
         $listName = uniqid();
         $value = uniqid();
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
-        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, refreshTtl: false);
+        $response = $this->client->listPushBack($this->TEST_CACHE_NAME, $listName, $value, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->listLength($this->TEST_CACHE_NAME, $listName);
@@ -1799,7 +1801,7 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->dictionaryGetField($this->TEST_CACHE_NAME, $dictionaryName, $field);
@@ -1813,7 +1815,7 @@ class CacheClientTest extends TestCase
         $dictionaryName = uniqid();
         $field = uniqid();
         $value = str_repeat("a", 256);
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, $value, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
         $response = $this->client->dictionaryGetField($this->TEST_CACHE_NAME, $dictionaryName, $field);
@@ -1829,7 +1831,7 @@ class CacheClientTest extends TestCase
         $field = uniqid();
         $value = uniqid();
         for ($i = 0; $i < 5; $i++) {
-            $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, "$field-$i", $value, false);
+            $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, "$field-$i", $value, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
             $this->assertNull($response->asError());
         }
         $response = $this->client->dictionaryFetch($this->TEST_CACHE_NAME, $dictionaryName);
@@ -1842,14 +1844,14 @@ class CacheClientTest extends TestCase
     {
         $dictionaryName = uniqid();
         $field = uniqid();
-        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "1", false);
+        $response = $this->client->dictionarySetField($this->TEST_CACHE_NAME, $dictionaryName, $field, "1", CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 2");
 
-        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 10, refreshTtl: false);
+        $response = $this->client->dictionaryIncrement($this->TEST_CACHE_NAME, $dictionaryName, $field, amount: 10, ttl: CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertEquals("$response", get_class($response) . ": 12");
     }
@@ -1859,14 +1861,14 @@ class CacheClientTest extends TestCase
         $this->expectException(TypeError::class);
         $setName = uniqid();
         $element = uniqid();
-        $this->client->setAddElement(null, $setName, $element, false);
+        $this->client->setAddElement(null, $setName, $element, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
     }
 
     public function testSetAddElementWithEmptyCacheName_ThrowsException()
     {
         $setName = uniqid();
         $element = uniqid();
-        $response = $this->client->setAddElement("", $setName, $element, false);
+        $response = $this->client->setAddElement("", $setName, $element, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1875,13 +1877,13 @@ class CacheClientTest extends TestCase
     {
         $this->expectException(TypeError::class);
         $element = uniqid();
-        $this->client->setAddElement($this->TEST_CACHE_NAME, null, $element, false);
+        $this->client->setAddElement($this->TEST_CACHE_NAME, null, $element, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
     }
 
     public function testSetAddElementWithEmptySetName_ThrowsException()
     {
         $element = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, "", $element, false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, "", $element, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1890,13 +1892,13 @@ class CacheClientTest extends TestCase
     {
         $this->expectException(TypeError::class);
         $setName = uniqid();
-        $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, null, false);
+        $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, null, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
     }
 
     public function testSetAddElementWithEmptyElement_ThrowsException()
     {
         $setName = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, "", false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, "", CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
@@ -1933,7 +1935,7 @@ class CacheClientTest extends TestCase
     {
         $setName = uniqid();
         $element = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -1947,12 +1949,12 @@ class CacheClientTest extends TestCase
     {
         $setName = uniqid();
         $element = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, false, 5);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(1);
 
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, false, 10);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(4);
@@ -1966,11 +1968,11 @@ class CacheClientTest extends TestCase
     {
         $setName = uniqid();
         $element = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, false, 2);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, ttlSeconds: 10);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, CollectionTtl::of(10));
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
         sleep(2);
@@ -2031,7 +2033,7 @@ class CacheClientTest extends TestCase
     {
         $setName = uniqid();
         $element = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, $element, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
 
@@ -2108,13 +2110,13 @@ class CacheClientTest extends TestCase
     public function testSetDelete_SetExists_HappyPath()
     {
         $setName = uniqid();
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
-        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), false);
+        $response = $this->client->setAddElement($this->TEST_CACHE_NAME, $setName, uniqid(), CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
         $this->assertNull($response->asError());
         $this->assertNotNull($response->asSuccess(), "Expected a success but got ${response}.");
 


### PR DESCRIPTION
- Made `$refreshTtl` optional and default to `true`.
- re-ordered arguments for list push and dictionary increment operations so that `$trunncateFrontToSie`, `$truncateBackToSize`, and `amount` are before `$refreshTtl`.
- updated the tests to reflect the above changes.

This PR needs to get merged before working on #54.

Closes #49 
Closes #50 