### PR TITLE
fix: declare string provider properties

### DIFF
--- a/src/Auth/StringMomentoTokenProvider.php
+++ b/src/Auth/StringMomentoTokenProvider.php
@@ -11,6 +11,12 @@ use function Momento\Utilities\isNullOrEmpty;
  */
 class StringMomentoTokenProvider extends CredentialProvider
 {
+    protected string  $authToken;
+    protected ?string $controlEndpoint = null;
+    protected ?string $cacheEndpoint = null;
+    protected ?string $trustedControlEndpointCertificateName = null;
+    protected ?string $trustedCacheEndpointCertificateName = null;
+
     public function __construct(
         string  $authToken,
         ?string $controlEndpoint = null,


### PR DESCRIPTION
I'm getting [deprecation warnings](https://www.php.net/manual/en/migration82.deprecated.php) with PHP 8.2 because the `StringMomentoTokenProvider` properties aren't declared in the class. This commit declares the properties.