### PR TITLE
fix: rename items to elements

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -503,7 +503,7 @@ class CacheClient implements LoggerAwareInterface
      *
      * @param string $cacheName Name of the cache that contains the dictionary.
      * @param string $dictionaryName The dictionary to set the field in. Will be created if it doesn't exist.
-     * @param array $items The field-value pairs o be stored.
+     * @param array $elements The field-value pairs to be stored.
      * @param CollectionTtl|null $ttl TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
      * @return DictionarySetFieldsResponse Represents the result of the dictionary set field operation.
      * This result is resolved to a type-safe object of one of the following types:<br>
@@ -514,9 +514,9 @@ class CacheClient implements LoggerAwareInterface
      * &nbsp;&nbsp;// handle error condition<br>
      * }</code>
      */
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?CollectionTtl $ttl = null): DictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $elements, ?CollectionTtl $ttl = null): DictionarySetFieldsResponse
     {
-        return $this->dataClient->dictionarySetFields($cacheName, $dictionaryName, $items, $ttl);
+        return $this->dataClient->dictionarySetFields($cacheName, $dictionaryName, $elements, $ttl);
     }
 
     /**

--- a/src/Cache/Internal/ScsDataClient.php
+++ b/src/Cache/Internal/ScsDataClient.php
@@ -124,7 +124,6 @@ use function Momento\Utilities\validateDictionaryName;
 use function Momento\Utilities\validateElement;
 use function Momento\Utilities\validateFieldName;
 use function Momento\Utilities\validateFields;
-use function Momento\Utilities\validateItems;
 use function Momento\Utilities\validateKeys;
 use function Momento\Utilities\validateListName;
 use function Momento\Utilities\validateNullOrEmpty;
@@ -560,16 +559,16 @@ class ScsDataClient implements LoggerAwareInterface
         return new DictionaryFetchMiss();
     }
 
-    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $items, ?CollectionTtl $ttl = null): DictionarySetFieldsResponse
+    public function dictionarySetFields(string $cacheName, string $dictionaryName, array $elements, ?CollectionTtl $ttl = null): DictionarySetFieldsResponse
     {
         try {
             $collectionTtl = $this->returnCollectionTtl($ttl);
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
-            validateKeys(array_keys($items));
+            validateKeys(array_keys($elements));
             $ttlMillis = $this->ttlToMillis($collectionTtl->getTtl());
             $protoItems = [];
-            foreach ($items as $field => $value) {
+            foreach ($elements as $field => $value) {
                 $fieldValuePair = new _DictionaryFieldValuePair();
                 $fieldValuePair->setField($field);
                 $fieldValuePair->setValue($value);
@@ -595,7 +594,7 @@ class ScsDataClient implements LoggerAwareInterface
         try {
             validateCacheName($cacheName);
             validateDictionaryName($dictionaryName);
-            validateItems($fields);
+            validateFields($fields);
             $dictionaryGetFieldsRequest = new _DictionaryGetRequest();
             $dictionaryGetFieldsRequest->setDictionaryName($dictionaryName);
             $dictionaryGetFieldsRequest->setFields($fields);

--- a/src/Utilities/_DataValidation.php
+++ b/src/Utilities/_DataValidation.php
@@ -103,13 +103,6 @@ if (!function_exists('validateValueName')) {
     }
 }
 
-if (!function_exists('validateItems')) {
-    function validateItems(array $items): void
-    {
-        validateNullOrEmptyList($items, "Items");
-    }
-}
-
 if (!function_exists('validateOperationTimeout')) {
     function validateOperationTimeout(?int $operationTimeout = null)
     {


### PR DESCRIPTION
This commit renames `items` to `elements` for `dictionarySetFields` to conform to naming conventions. It also removes an unused validator function.