### PR TITLE
feat: Add a prototype async get method

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -14,6 +14,7 @@ use Momento\Cache\CacheOperationTypes\DictionaryRemoveFieldsResponse;
 use Momento\Cache\CacheOperationTypes\DictionarySetFieldResponse;
 use Momento\Cache\CacheOperationTypes\DictionarySetFieldsResponse;
 use Momento\Cache\CacheOperationTypes\GetResponse;
+use Momento\Cache\CacheOperationTypes\GetResponseFuture;
 use Momento\Cache\CacheOperationTypes\IncrementResponse;
 use Momento\Cache\CacheOperationTypes\KeyExistsResponse;
 use Momento\Cache\CacheOperationTypes\KeysExistResponse;
@@ -177,6 +178,28 @@ class CacheClient implements LoggerAwareInterface
      * }</code>
      */
     public function get(string $cacheName, string $key): GetResponse
+    {
+        return $this->dataClient->get($cacheName, $key)();
+    }
+
+    /**
+     * Gets the cache value stored for a given key.
+     *
+     * @param string $cacheName Name of the cache to perform the lookup in.
+     * @param string $key The key to look up.
+     * @return GetResponseFuture An object that can be invoked to get the result of the get operation. This
+     * result is resolved to a type-safe object of one of the following types:<br>
+     * * GetHit<br>
+     * * GetMiss<br>
+     * * GetError<br>
+     * Pattern matching can be to operate on the appropriate subtype:<br>
+     * <code>if ($hit = $response->asHit()) {<br>
+     * &nbsp;&nbsp;$value = $hit->valueString();<br>
+     * } elseif ($error = $response->asError()) {<br>
+     * &nbsp;&nbsp;// handle error response<br>
+     * }</code>
+     */
+    public function getAsync(string $cacheName, string $key): GetResponseFuture
     {
         return $this->dataClient->get($cacheName, $key);
     }

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -426,6 +426,28 @@ class SetError extends SetResponse
 }
 
 /**
+ * Represents an asynchronous get call. Invoking it will wait for the call to complete and return the result.
+ */
+class GetResponseFuture
+{
+    private $callable;
+    private ?GetResponse $response = null;
+
+
+    public function __construct(callable $getResponseCallable)
+    {
+        $this->callable = $getResponseCallable;
+    }
+
+    public function __invoke(): GetResponse {
+        if ($this->response === null) {
+            $this->response = ($this->callable)();
+        }
+        return $this->response;
+    }
+}
+
+/**
  * Parent response type for a get request. The
  * response object is resolved to a type-safe object of one of
  * the following subtypes:

--- a/tests/Cache/GetTimingTest.php
+++ b/tests/Cache/GetTimingTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Momento\Tests\Cache;
+
+use Momento\Auth\EnvMomentoTokenProvider;
+use Momento\Cache\CacheClient;
+use Momento\Config\Configurations;
+use PHPUnit\Framework\TestCase;
+
+class GetTimingTest extends TestCase
+{
+    private int $DEFAULT_TTL_SECONDS = 600;
+    private CacheClient $client;
+    private string $TEST_CACHE_NAME;
+
+    public function setUp(): void
+    {
+        $configuration = Configurations\Laptop::latest();
+        $authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+        $this->client = new CacheClient($configuration, $authProvider, $this->DEFAULT_TTL_SECONDS);
+        $this->TEST_CACHE_NAME = uniqid('php-integration-tests-');
+        // Ensure test cache exists
+        $createResponse = $this->client->createCache($this->TEST_CACHE_NAME);
+        if ($createError = $createResponse->asError()) {
+            throw $createError->innerException();
+        }
+    }
+
+    public function tearDown() : void {
+        $deleteResponse = $this->client->deleteCache($this->TEST_CACHE_NAME);
+        if ($deleteError = $deleteResponse->asError()) {
+            throw $deleteError->innerException();
+        }
+    }
+    public function testGetTiming()
+    {
+        $cacheName = uniqid();
+        $key = uniqid();
+        $value = uniqid();
+        $response = $this->client->createCache($cacheName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+
+        $response = $this->client->set($cacheName, $key, $value);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        $this->assertEquals("$response", get_class($response));
+
+
+        $times = array();
+        for ($i = 0; $i < 10; $i++) {
+            sleep(2);
+
+            $startTime = hrtime(true);
+
+            $responses = array();
+            for ($j = 0; $j < 50; $j++) {
+                $responses[] = $this->client->get($cacheName, $key);
+            }
+
+            foreach ($responses as $response) {
+                $this->assertNull($response->asError());
+                $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
+                $response = $response->asHit();
+                $this->assertEquals($response->valueString(), $value);
+                $this->assertEquals("$response", get_class($response) . ": $value");
+            }
+
+            $elapsedTime = (hrtime(true) - $startTime) / 1e9;
+            $times[] = $elapsedTime;
+        }
+        print "Synchronous times:";
+        print_r($times);
+        printf("Average synchronous time: %.9f seconds\n", array_sum($times) / count($times));
+
+        $response = $this->client->deleteCache($cacheName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+    }
+
+    public function testGetAsyncTiming()
+    {
+        $cacheName = uniqid();
+        $key = uniqid();
+        $value = uniqid();
+        $response = $this->client->createCache($cacheName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+
+        $response = $this->client->set($cacheName, $key, $value);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        $this->assertEquals("$response", get_class($response));
+
+
+        $times = array();
+        for ($i = 0; $i < 10; $i++) {
+            sleep(2);
+
+            $startTime = hrtime(true);
+
+            $responseFutures = array();
+            for ($j = 0; $j < 50; $j++) {
+                $responseFutures[] = $this->client->getAsync($cacheName, $key);
+            }
+
+            foreach ($responseFutures as $responseFuture) {
+                $response = $responseFuture();
+                $this->assertNull($response->asError());
+                $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
+                $response = $response->asHit();
+                $this->assertEquals($response->valueString(), $value);
+                $this->assertEquals("$response", get_class($response) . ": $value");
+            }
+
+            $elapsedTime = (hrtime(true) - $startTime) / 1e9;
+            $times[] = $elapsedTime;
+        }
+        print "Async times:";
+        print_r($times);
+        printf("Average async time: %.9f seconds\n", array_sum($times) / count($times));
+
+        $response = $this->client->deleteCache($cacheName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+    }
+}


### PR DESCRIPTION
Add an async get method that separates the grpc call from interpreting the results. This is significantly faster depending on how the method is used.

Add a temporary test that runs the sync and async get methods in groups of 50 ten times and prints how long it takes. The async method is ~24x faster in this test.

If we wanted to reduce effort on adding async methods, we could make the async versions return a callable instead of a special future class, but then we would lose type hinting.

We could also hide the async methods entirely by making the `isHit()`/`asHit()` methods implicitly call the callable instead of providing it to the user. This would maintain compatibility with all of the tests except for the toString() tests. The downside is that it wouldn't be obvious that the methods were asynchronous unless the user reads the documentation.