### PR TITLE
fix: explicitly close gRPC channel when cycling idle client

### DIFF
--- a/src/Cache/Internal/IdleDataClientWrapper.php
+++ b/src/Cache/Internal/IdleDataClientWrapper.php
@@ -35,6 +35,7 @@ class IdleDataClientWrapper implements LoggerAwareInterface {
         $this->logger->debug("Checking to see if client has been idle for more than {$this->maxIdleMillis}");
         if ($this->getMilliseconds() - $this->lastAccessTime > $this->maxIdleMillis) {
             $this->logger->debug("Client has been idle for more than {$this->maxIdleMillis}; reconnecting");
+            $this->client->close();
             $this->client = ($this->clientFactory->callback)();
         }
         $this->lastAccessTime = $this->getMilliseconds();

--- a/src/Cache/Internal/ScsDataClient.php
+++ b/src/Cache/Internal/ScsDataClient.php
@@ -779,4 +779,8 @@ class ScsDataClient implements LoggerAwareInterface
         }
         return new SetRemoveElementSuccess();
     }
+
+    public function close(): void {
+        $this->grpcManager->close();
+    }
 }


### PR DESCRIPTION
Prior to this commit we didn't ever have an explicit call to close
the gRPC channel; in cases where we are cycling the client out
due to reaching the idle timeout, this could leave open sockets /
file descriptors behind.  This commit updates the code to explicitly
close the channel when replacing the client.
