### PR TITLE
feat: Implement set union operation

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -25,6 +25,7 @@ use Momento\Cache\CacheOperationTypes\ListPushBackResponse;
 use Momento\Cache\CacheOperationTypes\ListPushFrontResponse;
 use Momento\Cache\CacheOperationTypes\ListRemoveValueResponse;
 use Momento\Cache\CacheOperationTypes\SetAddElementResponse;
+use Momento\Cache\CacheOperationTypes\SetUnionResponse;
 use Momento\Cache\CacheOperationTypes\SetFetchResponse;
 use Momento\Cache\CacheOperationTypes\SetIfNotExistsResponse;
 use Momento\Cache\CacheOperationTypes\SetRemoveElementResponse;
@@ -667,6 +668,26 @@ class CacheClient implements LoggerAwareInterface
     public function setAddElement(string $cacheName, string $setName, string $element, ?CollectionTtl $ttl = null): SetAddElementResponse
     {
         return $this->dataClientWrapper->getClient()->setAddElement($cacheName, $setName, $element, $ttl);
+    }
+
+    /**
+     * Add many elements to a set.
+     *
+     * @param string $cacheName Name of the cache that contains the set.
+     * @param string $setName The set to add the element to.
+     * @param list<string> $elements The elements to add.
+     * @param CollectionTtl|null $ttl TTL for the dictionary in cache. This TTL takes precedence over the TTL used when initializing a cache client. Defaults to client TTL.
+     * @return SetUnionResponse Represents the result of the set union operation.
+     * This result is resolved to a type-safe object of one of the following types:<br>
+     * * SetUnionSuccess<br>
+     * * SetUnionError<br>
+     * if ($error = $response->asError()) {<br>
+     * &nbsp;&nbsp;// handle error condition<br>
+     * }</code>
+     */
+    public function setUnion(string $cacheName, string $setName, array $elements, ?CollectionTtl $ttl = null): SetUnionResponse
+    {
+        return $this->dataClientWrapper->getClient()->setUnion($cacheName, $setName, $elements, $ttl);
     }
 
     /**

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -2190,6 +2190,63 @@ class SetAddElementError extends SetAddElementResponse
 }
 
 /**
+ * Parent response type for a set union request. The response object
+ * is resolved to a type-safe object of one of the following subtypes:
+ *
+ * * SetUnionSuccess
+ * * SetUnionError
+ *
+ * Pattern matching can be used to operate on the appropriate subtype.
+ * For example:
+ * <code>
+ * if ($response->asSuccess()) {
+ *     // handle success as appropriate
+ * } elseif ($error = $response->asError())
+ *     // handle error as appropriate
+ * }
+ * </code>
+ */
+abstract class SetUnionResponse extends ResponseBase
+{
+    /**
+     * @return SetUnionSuccess|null Returns the success subtype if the request was successful and null otherwise.
+     */
+    public function asSuccess(): SetUnionSuccess|null
+    {
+        if ($this->isSuccess()) {
+            return $this;
+        }
+        return null;
+    }
+
+    /**
+     * @return SetUnionError|null Returns the error subtype if the request returned an error and null otherwise.
+     */
+    public function asError(): SetUnionError|null
+    {
+        if ($this->isError()) {
+            return $this;
+        }
+        return null;
+    }
+}
+
+/**
+ * Indicates that the request that generated it was successful.
+ */
+class SetUnionSuccess extends SetUnionResponse
+{
+}
+
+/**
+ * Contains information about an error returned from the request.
+ */
+class SetUnionError extends SetUnionResponse
+{
+    use ErrorBody;
+}
+
+/**
  * Parent response type for a set fetch request. The
  * response object is resolved to a type-safe object of one of
  * the following subtypes:

--- a/src/Utilities/_DataValidation.php
+++ b/src/Utilities/_DataValidation.php
@@ -141,6 +141,13 @@ if (!function_exists('validateElement')) {
     }
 }
 
+if (!function_exists('validateElements')) {
+    function validateElements(array $elements): void
+    {
+        validateNullOrEmptyList($elements, "Elements");
+    }
+}
+
 if (!function_exists('validatePsr16Key')) {
     function validatePsr16Key(string $key): void
     {

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -1990,6 +1990,61 @@ class CacheClientTest extends TestCase
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
 
+    public function testSetUnionWithNullCacheName_ThrowsException()
+    {
+        $this->expectException(TypeError::class);
+        $setName = uniqid();
+        $elements = [uniqid(), uniqid()];
+        $this->client->setUnion(null, $setName, $elements, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+    }
+
+    public function testSetUnionWithEmptyCacheName_ThrowsException()
+    {
+        $setName = uniqid();
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion("", $setName, $elements, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+        $this->assertNotNull($response->asError(), "Expected error but got: $response");
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
+    public function testSetUnionWithNullSetName_ThrowsException()
+    {
+        $this->expectException(TypeError::class);
+        $elements = [uniqid(), uniqid()];
+        $this->client->setUnion($this->TEST_CACHE_NAME, null, $elements, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+    }
+
+    public function testSetUnionWithEmptySetName_ThrowsException()
+    {
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, "", $elements, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+        $this->assertNotNull($response->asError(), "Expected error but got: $response");
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
+    public function testSetUnionWithNullElements_ThrowsException()
+    {
+        $this->expectException(TypeError::class);
+        $setName = uniqid();
+        $this->client->setUnion($this->TEST_CACHE_NAME, $setName, null, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+    }
+
+    public function testSetUnionWithNoElements_ThrowsException()
+    {
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, [], CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+        $this->assertNotNull($response->asError(), "Expected error but got: $response");
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
+    public function testSetUnionWithEmptyElement_ThrowsException()
+    {
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, [''], CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+        $this->assertNotNull($response->asError(), "Expected error but got: $response");
+        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
+    }
+
     public function testSetFetchWithNullCacheName_ThrowsException()
     {
         $this->expectException(TypeError::class);
@@ -2068,6 +2123,58 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
         $this->assertEquals($element, $response->asHit()->valuesArray()[0]);
     }
+
+    public function testSetUnionSetFetch_HappyPath()
+    {
+        $setName = uniqid();
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, $elements, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+
+        $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
+        $this->assertEquals($elements, $response->asHit()->valuesArray());
+    }
+
+    public function testSetUnionSetFetch_NoRefreshTtl()
+    {
+        $setName = uniqid();
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, $elements, CollectionTtl::of(5)->withNoRefreshTtlOnUpdates());
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        sleep(1);
+
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, $elements, CollectionTtl::of(10)->withNoRefreshTtlOnUpdates());
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        sleep(4);
+
+        $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asMiss(), "Expected a miss but got: $response");
+    }
+
+    public function testSetUnionSetFetch_RefreshTtl()
+    {
+        $setName = uniqid();
+        $elements = [uniqid(), uniqid()];
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, $elements, CollectionTtl::of(2)->withNoRefreshTtlOnUpdates());
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+
+        $response = $this->client->setUnion($this->TEST_CACHE_NAME, $setName, $elements, CollectionTtl::of(10));
+        $this->assertNull($response->asError());
+        $this->assertNotNull($response->asSuccess(), "Expected a success but got: $response");
+        sleep(2);
+
+        $response = $this->client->setFetch($this->TEST_CACHE_NAME, $setName);
+        $this->assertNotNull($response->asHit(), "Expected a hit but got: $response");
+        $this->assertEquals($elements, $response->asHit()->valuesArray());
+    }
+
 
     public function testSetRemoveElementWithNullCacheName_ThrowsException()
     {


### PR DESCRIPTION
Adds support for adding multiple items to a set in a single request, implementing using the existing operation already implemented in the underlying gRPC client.