### PR TITLE
fix: use $_SERVER instead of getenv

### DIFF
--- a/src/Auth/EnvMomentoTokenProvider.php
+++ b/src/Auth/EnvMomentoTokenProvider.php
@@ -19,7 +19,7 @@ class EnvMomentoTokenProvider extends StringMomentoTokenProvider
         ?string $trustedCacheEndpointCertificateName = null
     )
     {
-        $authToken = getenv($envVariableName);
+        $authToken = $_SERVER[$envVariableName];
         if ($authToken === false || isNullOrEmpty($authToken)) {
             throw new InvalidArgumentError("Environment variable $envVariableName is empty or null.");
         }

--- a/src/Auth/EnvMomentoTokenProvider.php
+++ b/src/Auth/EnvMomentoTokenProvider.php
@@ -19,7 +19,7 @@ class EnvMomentoTokenProvider extends StringMomentoTokenProvider
         ?string $trustedCacheEndpointCertificateName = null
     )
     {
-        if (! array_key_exists($envVariableName, $_SERVER)) {
+        if ((! array_key_exists($envVariableName, $_SERVER)) || $_SERVER[$envVariableName] == null) {
             throw new InvalidArgumentError("Environment variable $envVariableName is empty or null.");
         }
         $authToken = $_SERVER[$envVariableName];

--- a/src/Auth/EnvMomentoTokenProvider.php
+++ b/src/Auth/EnvMomentoTokenProvider.php
@@ -19,10 +19,10 @@ class EnvMomentoTokenProvider extends StringMomentoTokenProvider
         ?string $trustedCacheEndpointCertificateName = null
     )
     {
-        $authToken = $_SERVER[$envVariableName];
-        if ($authToken === false || isNullOrEmpty($authToken)) {
+        if (! array_key_exists($envVariableName, $_SERVER)) {
             throw new InvalidArgumentError("Environment variable $envVariableName is empty or null.");
         }
+        $authToken = $_SERVER[$envVariableName];
         parent::__construct($authToken, $controlEndpoint, $cacheEndpoint, $trustedControlEndpointCertificateName, $trustedCacheEndpointCertificateName);
     }
 }

--- a/src/Auth/EnvMomentoTokenProvider.php
+++ b/src/Auth/EnvMomentoTokenProvider.php
@@ -19,7 +19,7 @@ class EnvMomentoTokenProvider extends StringMomentoTokenProvider
         ?string $trustedCacheEndpointCertificateName = null
     )
     {
-        if ((! array_key_exists($envVariableName, $_SERVER)) || $_SERVER[$envVariableName] == null) {
+        if (isNullOrEmpty($_SERVER[$envVariableName] ?? null)) {
             throw new InvalidArgumentError("Environment variable $envVariableName is empty or null.");
         }
         $authToken = $_SERVER[$envVariableName];

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -54,9 +54,9 @@ class CacheClientTest extends TestCase
     private function getBadAuthTokenClient(): CacheClient
     {
         $badEnvName = "_MOMENTO_BAD_AUTH_TOKEN";
-        putenv("{$badEnvName}={$this->BAD_AUTH_TOKEN}");
+        $_SERVER[$badEnvName] = $this->BAD_AUTH_TOKEN;
         $authProvider = new EnvMomentoTokenProvider($badEnvName);
-        putenv($badEnvName);
+        unset($_SERVER[$badEnvName]);
         return new CacheClient($this->configuration, $authProvider, $this->DEFAULT_TTL_SECONDS);
     }
 

--- a/tests/Cache/MomentoTokenProviderTest.php
+++ b/tests/Cache/MomentoTokenProviderTest.php
@@ -24,9 +24,9 @@ class MomentoTokenProviderTest extends TestCase
     public function setUp(): void
     {
         try {
-            $this->authToken = getenv(self::AUTH_TOKEN_NAME);
+            $this->authToken = $_SERVER[self::AUTH_TOKEN_NAME];
         } catch (TypeError) {
-            // getenv returned false
+            // environment variable was not set
             throw new RuntimeException(
                 "Integration tests require TEST_AUTH_TOKEN environment variable"
             );

--- a/tests/Cache/MomentoTokenProviderTest.php
+++ b/tests/Cache/MomentoTokenProviderTest.php
@@ -23,14 +23,13 @@ class MomentoTokenProviderTest extends TestCase
 
     public function setUp(): void
     {
-        try {
-            $this->authToken = $_SERVER[self::AUTH_TOKEN_NAME];
-        } catch (TypeError) {
-            // environment variable was not set
+        if (!isset($_SERVER[self::AUTH_TOKEN_NAME])) {
             throw new RuntimeException(
-                "Integration tests require TEST_AUTH_TOKEN environment variable"
+                sprintf("Integration tests require %s environment variable", self::AUTH_TOKEN_NAME)
             );
         }
+
+        $this->authToken = $_SERVER[self::AUTH_TOKEN_NAME];
     }
 
     public function testEnvVarToken_HappyPath()


### PR DESCRIPTION
This commit changes our token provider code to use $_SERVER
instead of `getenv`. `getenv` is not threadsafe and can cause
security issues.
