### PR TITLE
feat: add configurability for number of gRPC channels

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -54,7 +54,12 @@ class CacheClient implements LoggerAwareInterface
     protected ILoggerFactory $loggerFactory;
     protected LoggerInterface $logger;
     private ScsControlClient $controlClient;
-    private IdleDataClientWrapper $dataClientWrapper;
+
+    /**
+     * @var IdleDataClientWrapper[]
+     */
+    private array $dataClients;
+    private int $nextDataClientIndex = 0;
 
     /**
      * @param IConfiguration $configuration Configuration to use for transport.
@@ -77,7 +82,10 @@ class CacheClient implements LoggerAwareInterface
                 $defaultTtlSeconds
             );
         };
-        $this->dataClientWrapper = new IdleDataClientWrapper($dataClientFactory, $this->configuration);
+        $this->dataClients = [];
+        for ($i = 0; $i < $configuration->getTransportStrategy()->getGrpcConfig()->getNumGrpcChannels(); $i++) {
+            array_push($this->dataClients, new IdleDataClientWrapper($dataClientFactory, $this->configuration));
+        }
     }
 
     /**
@@ -171,7 +179,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setAsync(string $cacheName, string $key, string $value, int $ttlSeconds = 0): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->set($cacheName, $key, $value, $ttlSeconds);
+        return $this->getNextDataClient()->set($cacheName, $key, $value, $ttlSeconds);
     }
 
     /**
@@ -223,7 +231,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function getAsync(string $cacheName, string $key): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->get($cacheName, $key);
+        return $this->getNextDataClient()->get($cacheName, $key);
     }
 
     /**
@@ -282,7 +290,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setIfNotExistsAsync(string $cacheName, string $key, string $value, int $ttlSeconds = 0): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->setIfNotExists($cacheName, $key, $value, $ttlSeconds);
+        return $this->getNextDataClient()->setIfNotExists($cacheName, $key, $value, $ttlSeconds);
     }
 
     /**
@@ -336,7 +344,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function deleteAsync(string $cacheName, string $key): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->delete($cacheName, $key);
+        return $this->getNextDataClient()->delete($cacheName, $key);
     }
 
     /**
@@ -387,7 +395,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function keysExistAsync(string $cacheName, array $keys): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->keysExist($cacheName, $keys);
+        return $this->getNextDataClient()->keysExist($cacheName, $keys);
     }
 
     /**
@@ -440,7 +448,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function keyExistsAsync(string $cacheName, string $key): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->keyExists($cacheName, $key);
+        return $this->getNextDataClient()->keyExists($cacheName, $key);
     }
 
     /**
@@ -495,7 +503,7 @@ class CacheClient implements LoggerAwareInterface
         string $cacheName, string $key, int $amount = 1, ?int $ttlSeconds = null
     ): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->increment($cacheName, $key, $amount, $ttlSeconds);
+        return $this->getNextDataClient()->increment($cacheName, $key, $amount, $ttlSeconds);
     }
 
     /**
@@ -543,7 +551,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function listFetch(string $cacheName, string $listName): ListFetchResponse
     {
-        return $this->dataClientWrapper->getClient()->listFetch($cacheName, $listName);
+        return $this->getNextDataClient()->listFetch($cacheName, $listName);
     }
 
     /**
@@ -569,7 +577,7 @@ class CacheClient implements LoggerAwareInterface
         string $cacheName, string $listName, string $value, ?int $truncateBackToSize = null, ?CollectionTtl $ttl = null
     ): ListPushFrontResponse
     {
-        return $this->dataClientWrapper->getClient()->listPushFront($cacheName, $listName, $value, $truncateBackToSize, $ttl);
+        return $this->getNextDataClient()->listPushFront($cacheName, $listName, $value, $truncateBackToSize, $ttl);
     }
 
     /**
@@ -595,7 +603,7 @@ class CacheClient implements LoggerAwareInterface
         string $cacheName, string $listName, string $value, ?int $truncateFrontToSize = null, ?CollectionTtl $ttl = null
     ): ListPushBackResponse
     {
-        return $this->dataClientWrapper->getClient()->listPushBack($cacheName, $listName, $value, $truncateFrontToSize, $ttl);
+        return $this->getNextDataClient()->listPushBack($cacheName, $listName, $value, $truncateFrontToSize, $ttl);
     }
 
     /**
@@ -617,7 +625,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function listPopFront(string $cacheName, string $listName): ListPopFrontResponse
     {
-        return $this->dataClientWrapper->getClient()->listPopFront($cacheName, $listName);
+        return $this->getNextDataClient()->listPopFront($cacheName, $listName);
     }
 
     /**
@@ -639,7 +647,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function listPopBack(string $cacheName, string $listName): ListPopBackResponse
     {
-        return $this->dataClientWrapper->getClient()->listPopBack($cacheName, $listName);
+        return $this->getNextDataClient()->listPopBack($cacheName, $listName);
     }
 
     /**
@@ -659,7 +667,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function listRemoveValue(string $cacheName, string $listName, string $value): ListRemoveValueResponse
     {
-        return $this->dataClientWrapper->getClient()->listRemoveValue($cacheName, $listName, $value);
+        return $this->getNextDataClient()->listRemoveValue($cacheName, $listName, $value);
     }
 
     /**
@@ -680,7 +688,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function listLength(string $cacheName, string $listName): ListLengthResponse
     {
-        return $this->dataClientWrapper->getClient()->listLength($cacheName, $listName);
+        return $this->getNextDataClient()->listLength($cacheName, $listName);
     }
 
     /**
@@ -702,7 +710,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionarySetField(string $cacheName, string $dictionaryName, string $field, string $value, ?CollectionTtl $ttl = null): DictionarySetFieldResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionarySetField($cacheName, $dictionaryName, $field, $value, $ttl);
+        return $this->getNextDataClient()->dictionarySetField($cacheName, $dictionaryName, $field, $value, $ttl);
     }
 
     /**
@@ -725,7 +733,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionaryGetField(string $cacheName, string $dictionaryName, string $field): DictionaryGetFieldResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionaryGetField($cacheName, $dictionaryName, $field);
+        return $this->getNextDataClient()->dictionaryGetField($cacheName, $dictionaryName, $field);
     }
 
     /**
@@ -747,7 +755,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionaryFetch(string $cacheName, string $dictionaryName): DictionaryFetchResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionaryFetch($cacheName, $dictionaryName);
+        return $this->getNextDataClient()->dictionaryFetch($cacheName, $dictionaryName);
     }
 
     /**
@@ -768,7 +776,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionarySetFields(string $cacheName, string $dictionaryName, array $elements, ?CollectionTtl $ttl = null): DictionarySetFieldsResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionarySetFields($cacheName, $dictionaryName, $elements, $ttl);
+        return $this->getNextDataClient()->dictionarySetFields($cacheName, $dictionaryName, $elements, $ttl);
     }
 
     /**
@@ -799,7 +807,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionaryGetFields(string $cacheName, string $dictionaryName, array $fields): DictionaryGetFieldsResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionaryGetFields($cacheName, $dictionaryName, $fields);
+        return $this->getNextDataClient()->dictionaryGetFields($cacheName, $dictionaryName, $fields);
     }
 
     /**
@@ -828,7 +836,7 @@ class CacheClient implements LoggerAwareInterface
         string $cacheName, string $dictionaryName, string $field, int $amount = 1, ?CollectionTtl $ttl = null
     ): DictionaryIncrementResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionaryIncrement($cacheName, $dictionaryName, $field, $amount, $ttl);
+        return $this->getNextDataClient()->dictionaryIncrement($cacheName, $dictionaryName, $field, $amount, $ttl);
     }
 
     /**
@@ -847,7 +855,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionaryRemoveField(string $cacheName, string $dictionaryName, string $field): DictionaryRemoveFieldResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionaryRemoveField($cacheName, $dictionaryName, $field);
+        return $this->getNextDataClient()->dictionaryRemoveField($cacheName, $dictionaryName, $field);
     }
 
     /**
@@ -866,7 +874,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function dictionaryRemoveFields(string $cacheName, string $dictionaryName, array $fields): DictionaryRemoveFieldsResponse
     {
-        return $this->dataClientWrapper->getClient()->dictionaryRemoveFields($cacheName, $dictionaryName, $fields);
+        return $this->getNextDataClient()->dictionaryRemoveFields($cacheName, $dictionaryName, $fields);
     }
 
     /**
@@ -895,7 +903,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setAddElementAsync(string $cacheName, string $setName, string $element, ?CollectionTtl $ttl = null): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->setAddElement($cacheName, $setName, $element, $ttl);
+        return $this->getNextDataClient()->setAddElement($cacheName, $setName, $element, $ttl);
     }
 
     /**
@@ -944,7 +952,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setAddElementsAsync(string $cacheName, string $setName, array $elements, ?CollectionTtl $ttl = null): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->setAddElements($cacheName, $setName, $elements, $ttl);
+        return $this->getNextDataClient()->setAddElements($cacheName, $setName, $elements, $ttl);
     }
 
     /**
@@ -994,7 +1002,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setFetchAsync(string $cacheName, string $setName): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->setFetch($cacheName, $setName);
+        return $this->getNextDataClient()->setFetch($cacheName, $setName);
     }
 
     /**
@@ -1044,7 +1052,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setLengthAsync(string $cacheName, string $setName): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->setLength($cacheName, $setName);
+        return $this->getNextDataClient()->setLength($cacheName, $setName);
     }
 
     /**
@@ -1093,7 +1101,7 @@ class CacheClient implements LoggerAwareInterface
      */
     public function setRemoveElementAsync(string $cacheName, string $setName, string $element): ResponseFuture
     {
-        return $this->dataClientWrapper->getClient()->setRemoveElement($cacheName, $setName, $element);
+        return $this->getNextDataClient()->setRemoveElement($cacheName, $setName, $element);
     }
 
     /**
@@ -1113,5 +1121,12 @@ class CacheClient implements LoggerAwareInterface
     public function setRemoveElement(string $cacheName, string $setName, string $element): SetRemoveElementResponse
     {
         return $this->setRemoveElementAsync($cacheName, $setName, $element)->wait();
+    }
+
+    private function getNextDataClient(): ScsDataClient
+    {
+        $client = $this->dataClients[$this->nextDataClientIndex]->getClient();
+        $this->nextDataClientIndex = ($this->nextDataClientIndex + 1) % sizeof($this->dataClients);
+        return $client;
     }
 }

--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -87,7 +87,7 @@ class CacheClient implements LoggerAwareInterface
 
         $numGrpcChannels = $configuration->getTransportStrategy()->getGrpcConfig()->getNumGrpcChannels();
         $forceNewChannels = $configuration->getTransportStrategy()->getGrpcConfig()->getForceNewChannel();
-        if (($numGrpcChannels > 0) && (! $forceNewChannels)) {
+        if (($numGrpcChannels > 1) && (! $forceNewChannels)) {
             throw new InvalidArgumentError("When setting NumGrpcChannels > 1, you must also set ForceNewChannel to true, or else the gRPC library will re-use the same channel.");
         }
         for ($i = 0; $i < $numGrpcChannels; $i++) {

--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -1133,7 +1133,7 @@ class CacheClient implements LoggerAwareInterface
     private function getNextDataClient(): ScsDataClient
     {
         $client = $this->dataClients[$this->nextDataClientIndex]->getClient();
-        $this->nextDataClientIndex = ($this->nextDataClientIndex + 1) % sizeof($this->dataClients);
+        $this->nextDataClientIndex = ($this->nextDataClientIndex + 1) % count($this->dataClients);
         return $client;
     }
 }

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -31,9 +31,9 @@ class Configuration implements IConfiguration
     }
 
     /**
-     * @return ITransportStrategy|null The currently active transport strategy
+     * @return ITransportStrategy The currently active transport strategy
      */
-    public function getTransportStrategy(): ITransportStrategy|null
+    public function getTransportStrategy(): ITransportStrategy
     {
         return $this->transportStrategy;
     }

--- a/src/Config/Configurations/Laptop.php
+++ b/src/Config/Configurations/Laptop.php
@@ -37,7 +37,7 @@ class Laptop extends Configuration
     {
         $loggerFactory = $loggerFactory ?? new NullLoggerFactory();
         $grpcConfig = new StaticGrpcConfiguration(5000);
-        $transportStrategy = new StaticTransportStrategy(null, $grpcConfig, $loggerFactory, self::$maxIdleMillis);
+        $transportStrategy = new StaticTransportStrategy($grpcConfig, $loggerFactory, self::$maxIdleMillis);
         return new Laptop($loggerFactory, $transportStrategy);
     }
 }

--- a/src/Config/IConfiguration.php
+++ b/src/Config/IConfiguration.php
@@ -16,6 +16,12 @@ interface IConfiguration
      */
     public function getLoggerFactory(): ILoggerFactory;
 
+
+    /**
+     * @return ITransportStrategy The currently active transport strategy
+     */
+    public function getTransportStrategy(): ITransportStrategy;
+
     /**
      * Creates a new instance of the Configuration object, updated to use the specified transport strategy.
      *

--- a/src/Config/Transport/IGrpcConfiguration.php
+++ b/src/Config/Transport/IGrpcConfiguration.php
@@ -12,4 +12,8 @@ interface IGrpcConfiguration
     public function getForceNewChannel(): ?bool;
 
     public function withForceNewChannel(bool $forceNewChannel) : IGrpcConfiguration;
+
+    public function getNumGrpcChannels(): int;
+
+    public function withNumGrpcChannels(int $numGrpcChannels): IGrpcConfiguration;
 }

--- a/src/Config/Transport/ITransportStrategy.php
+++ b/src/Config/Transport/ITransportStrategy.php
@@ -7,8 +7,6 @@ use Momento\Logging\ILoggerFactory;
 
 interface ITransportStrategy
 {
-    public function getMaxConcurrentRequests(): ?int;
-
     public function getGrpcConfig(): ?IGrpcConfiguration;
 
     public function getMaxIdleMillis(): ?int;

--- a/src/Config/Transport/StaticGrpcConfiguration.php
+++ b/src/Config/Transport/StaticGrpcConfiguration.php
@@ -7,12 +7,14 @@ class StaticGrpcConfiguration implements IGrpcConfiguration
 {
 
     private ?int $deadlineMilliseconds;
-    private ?bool $forceNewChannel;
+    private bool $forceNewChannel;
+    private int $numGrpcChannels;
 
-    public function __construct(?int $deadlineMilliseconds = null, ?bool $forceNewChannel = false)
+    public function __construct(?int $deadlineMilliseconds = null, bool $forceNewChannel = false, int $numGrpcChannels = 1)
     {
         $this->deadlineMilliseconds = $deadlineMilliseconds;
         $this->forceNewChannel = $forceNewChannel;
+        $this->numGrpcChannels = $numGrpcChannels;
     }
 
     public function getDeadlineMilliseconds(): int|null
@@ -22,7 +24,7 @@ class StaticGrpcConfiguration implements IGrpcConfiguration
 
     public function withDeadlineMilliseconds(int $deadlineMilliseconds): StaticGrpcConfiguration
     {
-        return new StaticGrpcConfiguration($deadlineMilliseconds, $this->forceNewChannel);
+        return new StaticGrpcConfiguration($deadlineMilliseconds, $this->forceNewChannel, $this->numGrpcChannels);
     }
 
     public function getForceNewChannel(): bool|null
@@ -32,6 +34,16 @@ class StaticGrpcConfiguration implements IGrpcConfiguration
 
     public function withForceNewChannel(bool $forceNewChannel): StaticGrpcConfiguration
     {
-        return new StaticGrpcConfiguration($this->deadlineMilliseconds, $forceNewChannel);
+        return new StaticGrpcConfiguration($this->deadlineMilliseconds, $forceNewChannel, $this->numGrpcChannels);
+    }
+
+    public function getNumGrpcChannels(): int
+    {
+        return $this->numGrpcChannels;
+    }
+
+    public function withNumGrpcChannels(int $numGrpcChannels): IGrpcConfiguration
+    {
+        return new StaticGrpcConfiguration($this->deadlineMilliseconds, $this->forceNewChannel, $numGrpcChannels);
     }
 }

--- a/src/Config/Transport/StaticTransportStrategy.php
+++ b/src/Config/Transport/StaticTransportStrategy.php
@@ -7,27 +7,19 @@ use Momento\Logging\ILoggerFactory;
 
 class StaticTransportStrategy implements ITransportStrategy
 {
-    private ?int $maxConcurrentRequests;
-    private ?IGrpcConfiguration $grpcConfig;
+    private IGrpcConfiguration $grpcConfig;
     private ?ILoggerFactory $loggerFactory;
     private ?int $maxIdleMillis;
 
     public function __construct(
-        ?int                $maxConcurrentRequests = null,
-        ?IGrpcConfiguration $grpcConfig = null,
+        IGrpcConfiguration $grpcConfig,
         ?ILoggerFactory     $loggerFactory = null,
         ?int                $maxIdleMillis = null,
     )
     {
-        $this->maxConcurrentRequests = $maxConcurrentRequests;
         $this->grpcConfig = $grpcConfig;
         $this->loggerFactory = $loggerFactory;
         $this->maxIdleMillis = $maxIdleMillis;
-    }
-
-    public function getMaxConcurrentRequests(): ?int
-    {
-        return $this->maxConcurrentRequests;
     }
 
     public function getGrpcConfig(): IGrpcConfiguration|null
@@ -43,28 +35,27 @@ class StaticTransportStrategy implements ITransportStrategy
     public function withLoggerFactory(ILoggerFactory $loggerFactory): StaticTransportStrategy
     {
         return new StaticTransportStrategy(
-            $this->maxConcurrentRequests, $this->grpcConfig, $loggerFactory, $this->maxIdleMillis
+            $this->grpcConfig, $loggerFactory, $this->maxIdleMillis
         );
     }
 
     public function withGrpcConfig(IGrpcConfiguration $grpcConfig): StaticTransportStrategy
     {
         return new StaticTransportStrategy(
-            $this->maxConcurrentRequests, $grpcConfig, $this->loggerFactory, $this->maxIdleMillis
+            $grpcConfig, $this->loggerFactory, $this->maxIdleMillis
         );
     }
 
     public function withMaxIdleMillis(int $maxIdleMillis): StaticTransportStrategy
     {
         return new StaticTransportStrategy(
-             $this->maxConcurrentRequests, $this->grpcConfig, $this->loggerFactory, $maxIdleMillis
+            $this->grpcConfig, $this->loggerFactory, $maxIdleMillis
         );
     }
 
     public function withClientTimeout(int $clientTimeout): StaticTransportStrategy
     {
         return new StaticTransportStrategy(
-            $this->maxConcurrentRequests,
             $this->grpcConfig->withDeadlineMilliseconds($clientTimeout),
             $this->loggerFactory,
             $this->maxIdleMillis

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -64,7 +64,7 @@ class CacheClientTest extends TestCase
     {
         $loggerFactory = new NullLoggerFactory();
         $grpcConfig = new StaticGrpcConfiguration($deadline);
-        $transportStrategy = new StaticTransportStrategy(null, $grpcConfig, $loggerFactory);
+        $transportStrategy = new StaticTransportStrategy($grpcConfig, $loggerFactory);
         return new Configuration($loggerFactory, $transportStrategy);
     }
 

--- a/tests/Cache/Psr16ClientTest.php
+++ b/tests/Cache/Psr16ClientTest.php
@@ -29,7 +29,7 @@ class Psr16ClientTest extends \PHPUnit\Framework\TestCase
     {
         $loggerFactory = new NullLoggerFactory();
         $grpcConfiguration = new StaticGrpcConfiguration(5000);
-        $transportStrategy = new StaticTransportStrategy(null, $grpcConfiguration);
+        $transportStrategy = new StaticTransportStrategy($grpcConfiguration);
         $configuration = new Configuration($loggerFactory, $transportStrategy);
         $authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
         $this->client = new Psr16CacheClient($configuration, $authProvider, $this->DEFAULT_TTL_SECONDS);


### PR DESCRIPTION
For users who may end up with over 100 concurrent requests in flight,
we need to be able to support multiple gRPC channels. This commit adds
a configuration setting to allow users to specify the desired number
of channels.

This most likely won't doing anything useful until we add the config
flag to disable persistent TCP connections in the gRPC channel
constructor, because we will just end up re-using the same channel
multiple times.
