### PR TITLE
feat: Improve PSR cache multiple operation performance

### DIFF
--- a/src/Cache/Psr16CacheClient.php
+++ b/src/Cache/Psr16CacheClient.php
@@ -194,7 +194,7 @@ class Psr16CacheClient implements CacheInterface
 
             foreach ($futures as $key => $future) {
                 $response = $future->wait();
-                $error = $response->asError()
+                $error = $response->asError();
                 if (null !== $error) {
                     $this->handleCacheError($error);
                     $result[$key] = $default;
@@ -240,7 +240,7 @@ class Psr16CacheClient implements CacheInterface
 
             foreach ($futures as $key => $future) {
                 $response = $future->wait();
-                $error = $response->asError()
+                $error = $response->asError();
                 if (null !== $error) {
                     $this->handleCacheError($error);
                     return false;
@@ -272,7 +272,7 @@ class Psr16CacheClient implements CacheInterface
 
             foreach ($futures as $key => $future) {
                 $response = $future->wait();
-                $error = $response->asError()
+                $error = $response->asError();
                 if (null !== $error) {
                     $this->handleCacheError($error);
                     return false;

--- a/src/Cache/Psr16CacheClient.php
+++ b/src/Cache/Psr16CacheClient.php
@@ -176,13 +176,36 @@ class Psr16CacheClient implements CacheInterface
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {
+        $keyList = [];
+
         foreach ($keys as $key) {
             validatePsr16Key($key);
+            $keyList[] = $key;
         }
+
         $result = [];
-        foreach ($keys as $key) {
-            $result[$key] = $this->get($key, $default);
+
+        foreach (array_chunk($keyList, 100) as $keyChunk) {
+            $futures = [];
+
+            foreach ($keyChunk as $key) {
+                $futures[$key] = $this->momento->getAsync(self::CACHE_NAME, $key);
+            }
+
+            foreach ($futures as $key => $future) {
+                $response = $future->wait();
+                $error = $response->asError()
+                if (null !== $error) {
+                    $this->handleCacheError($error);
+                    $result[$key] = $default;
+                } elseif (null !== $response->asMiss()) {
+                    $result[$key] = $default;
+                } else {
+                    $result[$key] = unserialize($response->asHit()->valueString());
+                }
+            }
         }
+
         return $result;
     }
 
@@ -191,15 +214,40 @@ class Psr16CacheClient implements CacheInterface
      */
     public function setMultiple(iterable $values, DateInterval|int|null $ttl = null): bool
     {
+        $keyValueMap = [];
+
         foreach ($values as $key => $value) {
             validatePsr16Key($key);
+            $keyValueMap[$key] = $value;
         }
-        foreach ($values as $key => $value) {
-            $result = $this->set($key, $value);
-            if ($result === false) {
-                return false;
+
+        if (is_null($ttl)) {
+            $ttl = self::DEFAULT_TTL_SECONDS;
+        } elseif ($ttl instanceof DateInterval) {
+            $ttl = self::dateIntervalToSeconds($ttl);
+        }
+
+        if ($ttl <= 0) {
+            return $this->deleteMultiple(array_keys($keyValueMap));
+        }
+
+        foreach (array_chunk($keyValueMap, 100, true) as $keyValueChunk) {
+            $futures = [];
+
+            foreach ($keyValueChunk as $key => $value) {
+                $futures[$key] = $this->momento->setAsync(self::CACHE_NAME, $key, serialize($value), $ttl);
+            }
+
+            foreach ($futures as $key => $future) {
+                $response = $future->wait();
+                $error = $response->asError()
+                if (null !== $error) {
+                    $this->handleCacheError($error);
+                    return false;
+                }
             }
         }
+
         return true;
     }
 
@@ -208,12 +256,30 @@ class Psr16CacheClient implements CacheInterface
      */
     public function deleteMultiple(iterable $keys): bool
     {
+        $keyList = [];
+
         foreach ($keys as $key) {
             validatePsr16Key($key);
+            $keyList[] = $key;
         }
-        foreach ($keys as $key) {
-            $this->delete($key);
+
+        foreach (array_chunk($keyList, 100) as $keyChunk) {
+            $futures = [];
+
+            foreach ($keyChunk as $key) {
+                $futures[$key] = $this->momento->deleteAsync(self::CACHE_NAME, $key);
+            }
+
+            foreach ($futures as $key => $future) {
+                $response = $future->wait();
+                $error = $response->asError()
+                if (null !== $error) {
+                    $this->handleCacheError($error);
+                    return false;
+                }
+            }
         }
+
         return true;
     }
 


### PR DESCRIPTION
I have adjusted these methods to perform up to 100 operations concurrently against the cache, and where there are more than 100 operations to do, it performs the first 100, then the next 100, etc. This also fixes a bug where it is attempted to iterate the keys more than once. An iterable in PHP need not implement the ability to rewind, so we must only iterate once.