### PR TITLE
feat: add `close` method for explicitly closing client

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -97,6 +97,19 @@ class CacheClient implements LoggerAwareInterface
     }
 
     /**
+     * Close the client and free up all associated resources. NOTE: the client object will not be usable after calling
+     * this method.
+     */
+    public function close(): void
+    {
+        $this->controlClient->close();
+        foreach ($this->dataClients as $dataClient) {
+            $dataClient->close();
+        }
+    }
+
+
+    /**
      * Assigns a LoggerInterface logging object to the client.
      *
      * @param LoggerInterface $logger Object to use for logging

--- a/src/Cache/Internal/IdleDataClientWrapper.php
+++ b/src/Cache/Internal/IdleDataClientWrapper.php
@@ -42,6 +42,10 @@ class IdleDataClientWrapper implements LoggerAwareInterface {
         return $this->client;
     }
 
+    public function close(): void {
+        $this->client->close();
+    }
+
     private function getMilliseconds(): int {
         return (int)(gettimeofday(true) * 1000);
     }

--- a/src/Cache/Internal/ScsControlClient.php
+++ b/src/Cache/Internal/ScsControlClient.php
@@ -45,6 +45,10 @@ class ScsControlClient implements LoggerAwareInterface
         $this->setLogger($this->loggerFactory->getLogger(get_class($this)));
     }
 
+    public function close(): void {
+        $this->grpcManager->close();
+    }
+
     public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -68,6 +68,17 @@ class CacheClientTest extends TestCase
         return new Configuration($loggerFactory, $transportStrategy);
     }
 
+    public function testCreateAndCloseClient() {
+        $client = new CacheClient($this->configuration, $this->authProvider, $this->DEFAULT_TTL_SECONDS);
+        $response = $client->listCaches();
+        $this->assertNull($response->asError());
+        $client->close();
+        $client = new CacheClient($this->configuration, $this->authProvider, $this->DEFAULT_TTL_SECONDS);
+        $response = $client->listCaches();
+        $this->assertNull($response->asError());
+        $client->close();
+    }
+
     // Happy path test
 
     public function testCreateSetGetDelete()


### PR DESCRIPTION
This is intended to help us determine whether or not a persistent gRPC connection that gets into a bad state can be explicitly closed and re-opened to restore the environment to a healthy state.