### PR TITLE
chore: rename TEST_AUTH_TOKEN to MOMENTO_API_KEY

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on-push-to-main.yaml
+++ b/.github/workflows/on-push-to-main.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/on-push-to-release.yaml
+++ b/.github/workflows/on-push-to-release.yaml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      TEST_AUTH_TOKEN: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,6 @@ You will likely need to run this only once:
 ## Run Integration Test
 
 ```bash
-export TEST_AUTH_TOKEN=<YOUR_API_KEY>
+export MOMENTO_API_KEY=<YOUR_API_KEY>
 ./dev-run-integration-tests.sh
 ```

--- a/dev-run-integration-tests.sh
+++ b/dev-run-integration-tests.sh
@@ -4,17 +4,17 @@ set -e
 set -x
 set -o pipefail
 
-if [ "$TEST_AUTH_TOKEN" == "" ]
+if [ "$MOMENTO_API_KEY" == "" ]
 then
-  echo "Missing required env var TEST_AUTH_TOKEN"
+  echo "Missing required env var MOMENTO_API_KEY"
   exit 1
 else
-    export TEST_AUTH_TOKEN=$TEST_AUTH_TOKEN
+    export MOMENTO_API_KEY=$MOMENTO_API_KEY
 fi
 
 DOCKER_IMAGE_NAME=momento-php-dev
 
 DOCKER_BASE_COMMAND="docker run -it -v$(pwd):/app -w=/app"
 $DOCKER_BASE_COMMAND $DOCKER_IMAGE_NAME composer install
-$DOCKER_BASE_COMMAND -e TEST_AUTH_TOKEN="$TEST_AUTH_TOKEN" \
+$DOCKER_BASE_COMMAND -e MOMENTO_API_KEY="$MOMENTO_API_KEY" \
 	$DOCKER_IMAGE_NAME php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -36,7 +36,7 @@ class CacheClientTest extends TestCase
     public function setUp(): void
     {
         $this->configuration = Configurations\Laptop::latest();
-        $this->authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+        $this->authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         $this->client = new CacheClient($this->configuration, $this->authProvider, $this->DEFAULT_TTL_SECONDS);
         $this->TEST_CACHE_NAME = uniqid('php-integration-tests-');
         // Ensure test cache exists

--- a/tests/Cache/MomentoTokenProviderTest.php
+++ b/tests/Cache/MomentoTokenProviderTest.php
@@ -19,7 +19,7 @@ class MomentoTokenProviderTest extends TestCase
 {
 
     private string $authToken;
-    const AUTH_TOKEN_NAME = 'TEST_AUTH_TOKEN';
+    const AUTH_TOKEN_NAME = 'MOMENTO_API_KEY';
 
     public function setUp(): void
     {

--- a/tests/Cache/Psr16ClientTest.php
+++ b/tests/Cache/Psr16ClientTest.php
@@ -35,7 +35,7 @@ class Psr16ClientTest extends TestCase
         $grpcConfiguration = new StaticGrpcConfiguration(5000);
         $transportStrategy = new StaticTransportStrategy($grpcConfiguration);
         $this->configuration = new Configuration($loggerFactory, $transportStrategy);
-        $this->authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+        $this->authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         $this->client = new Psr16CacheClient(
             $this->configuration, $this->authProvider, $this->DEFAULT_TTL_SECONDS
         );
@@ -108,7 +108,7 @@ class Psr16ClientTest extends TestCase
     {
         $testCacheName = uniqid("php-PSR16-name-test");
         $configuration = Laptop::latest();
-        $authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+        $authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         $client = new CacheClient(
             $configuration, $authProvider, $this->DEFAULT_TTL_SECONDS
         );

--- a/tests/Storage/StorageClientTest.php
+++ b/tests/Storage/StorageClientTest.php
@@ -30,7 +30,7 @@ class StorageClientTest extends TestCase
     public function setUp(): void
     {
         $this->configuration = Configurations\Storage\Laptop::latest();
-        $this->authProvider = new EnvMomentoTokenProvider("TEST_AUTH_TOKEN");
+        $this->authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         $this->client = new PreviewStorageClient($this->configuration, $this->authProvider);
         $this->TEST_STORE_NAME = uniqid("php-storage-integration-tests-");
         // Create a store for testing


### PR DESCRIPTION
just fixes a few straggling places where we hadn't finished this
env var rename.
