### PR TITLE
chore: support devcontainer development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/php:8.1-bookworm
+
+RUN pecl install grpc protobuf && docker-php-ext-enable grpc protobuf

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,9 +12,10 @@
 	// Configure tool-specific properties.
 
     "customizations" : {
-      "jetbrains" : {
-        "backend" : "IntelliJ",
-      }
+        "jetbrains" : {
+            "backend" : "IntelliJ",
+            "plugins": ["com.jetbrains.php"],
+        }
     },
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php
+{
+	"name": "PHP",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"dockerFile": "Dockerfile",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+    },
+
+	// Configure tool-specific properties.
+
+    "customizations" : {
+      "jetbrains" : {
+        "backend" : "IntelliJ",
+      }
+    },
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8080],
+
+    "containerEnv": {
+        "MOMENTO_API_KEY": "${localEnv:MOMENTO_API_KEY}"
+    },
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: install lint-check lint test
+
+install:
+	@echo "Installing dependencies..."
+	@composer install
+
+lint-check:
+	@echo "Checking code style..."
+	@php vendor/bin/php-cs-fixer fix --diff --dry-run --show-progress=none
+
+lint:
+	@echo "Fixing code style..."
+	@php vendor/bin/php-cs-fixer fix --diff --show-progress=none
+
+test:
+	@echo "Running tests..."
+	@php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml


### PR DESCRIPTION
We add a devcontainer and Dockerfile to do local develpoment in
IntelliJ. We also add a Makefile wtih the common dev targets.

To use in IntelliJ:
- Under services, add Docker
- Open the devcontainer.json in the project
- Right click the blue wireframe square in the gutter by the opening curly
![image](https://github.com/user-attachments/assets/e32c39c0-1d69-4dc7-85d3-967ec17f8abd)
Select "Create container and mount sources..."; select IntelliJ IDEA.
- Wait for it to download IntelliJ, build, and launch
- Develop in the new remote container IDE
- Use settings sync to get settings aligned between the host IntelliJ and guest
