### PR TITLE
ci: cache extensions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -9,7 +9,10 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-24.04
-
+    env:
+        php-version: 8.0
+        extensions: grpc, protobuf
+        key: ${{ runner.os }}-php-${{ env.php-version }}-extensions-${{ env.extensions }}
     steps:
       - uses: actions/checkout@v4
 
@@ -29,11 +32,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+            php-version: ${{ env.php-version }}
+            extensions: ${{ env.extensions }}
+            key: ${{ env.key }}
+
+      - name: Cache extensions
+        uses: actions/cache@v4
+        with:
+            path: ${{ steps.extcache.outputs.dir }}
+            key: ${{ steps.extcache.outputs.key }}
+            restore-keys: ${{ steps.extcache.outputs.key }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
-          extensions: grpc, protobuf
+          php-version: ${{ env.php-version }}
+          extensions: ${{ env.extensions }}
           tools: composer
 
       - name: Install dependencies
@@ -52,15 +70,32 @@ jobs:
 
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      extensions: grpc, protobuf
+      key: ${{ runner.os }}-php-${{ matrix.php-version }}-extensions-${{ env.extensions }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup cache environment
+        id: extcache
+        uses: shivammathur/cache-extensions@v1
+        with:
+            php-version: ${{ matrix.php-version }}
+            extensions: ${{ env.extensions }}
+            key: ${{ env.key }}
+
+      - name: Cache extensions
+        uses: actions/cache@v4
+        with:
+            path: ${{ steps.extcache.outputs.dir }}
+            key: ${{ steps.extcache.outputs.key }}
+            restore-keys: ${{ steps.extcache.outputs.key }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: grpc, protobuf
+          extensions: ${{ env.extensions }}
           tools: composer
 
       - name: Install dependencies

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       php-version: 8.0
       extensions: grpc, protobuf
-      key: php-${{ env.php-version }}-extensions-${{ env.extensions }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -32,13 +32,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set cache key
+        id: cache-key
+        run: echo "::set-output name=key::php-${{ env.php-version }}-extensions-grpc, protobuf"
+
       - name: Setup cache environment
         id: extcache
         uses: shivammathur/cache-extensions@v1
         with:
           php-version: ${{ env.php-version }}
           extensions: ${{ env.extensions }}
-          key: ${{ env.key }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Cache extensions
         uses: actions/cache@v4
@@ -71,10 +75,13 @@ jobs:
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       extensions: grpc, protobuf
-      key: php-${{ matrix.php-version }}-extensions-${{ env.extensions }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set cache key
+        id: cache-key
+        run: echo "::set-output name=key::php-${{ matrix.php-version }}"
 
       - name: Setup cache environment
         id: extcache
@@ -82,7 +89,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: ${{ env.extensions }}
-          key: ${{ env.key }}
+          key: ${{ steps.cache-key.outputs.key }}
 
       - name: Cache extensions
         uses: actions/cache@v4

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set cache key
         id: cache-key
-        run: echo "::set-output name=key::php-${{ env.php-version }}-extensions-grpc, protobuf"
+        run: echo "key=php-${{ env.php-version }}" >> $GITHUB_OUTPUT
 
       - name: Setup cache environment
         id: extcache
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set cache key
         id: cache-key
-        run: echo "::set-output name=key::php-${{ matrix.php-version }}"
+        run: echo "php-${{ matrix.php-version }}" >> $GITHUB_OUTPUT
 
       - name: Setup cache environment
         id: extcache

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: true
       matrix:
         php-version: ['7.4', '8.4']
-        #php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        #php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4'] # TODO: Uncomment to test all PHP versions
     runs-on: ubuntu-24.04
 
     env:

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-24.04
     env:
-        php-version: 8.0
-        extensions: grpc, protobuf
-        key: php-${{ env.php-version }}-extensions-${{ env.extensions }}
+      php-version: 8.0
+      extensions: grpc, protobuf
+      key: php-${{ env.php-version }}-extensions-${{ env.extensions }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,16 +36,16 @@ jobs:
         id: extcache
         uses: shivammathur/cache-extensions@v1
         with:
-            php-version: ${{ env.php-version }}
-            extensions: ${{ env.extensions }}
-            key: ${{ env.key }}
+          php-version: ${{ env.php-version }}
+          extensions: ${{ env.extensions }}
+          key: ${{ env.key }}
 
       - name: Cache extensions
         uses: actions/cache@v4
         with:
-            path: ${{ steps.extcache.outputs.dir }}
-            key: ${{ steps.extcache.outputs.key }}
-            restore-keys: ${{ steps.extcache.outputs.key }}
+          path: ${{ steps.extcache.outputs.dir }}
+          key: ${{ steps.extcache.outputs.key }}
+          restore-keys: ${{ steps.extcache.outputs.key }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -80,16 +80,16 @@ jobs:
         id: extcache
         uses: shivammathur/cache-extensions@v1
         with:
-            php-version: ${{ matrix.php-version }}
-            extensions: ${{ env.extensions }}
-            key: ${{ env.key }}
+          php-version: ${{ matrix.php-version }}
+          extensions: ${{ env.extensions }}
+          key: ${{ env.key }}
 
       - name: Cache extensions
         uses: actions/cache@v4
         with:
-            path: ${{ steps.extcache.outputs.dir }}
-            key: ${{ steps.extcache.outputs.key }}
-            restore-keys: ${{ steps.extcache.outputs.key }}
+          path: ${{ steps.extcache.outputs.dir }}
+          key: ${{ steps.extcache.outputs.key }}
+          restore-keys: ${{ steps.extcache.outputs.key }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -66,7 +66,7 @@ jobs:
 
   test:
     strategy:
-      max-parallel: 1
+      max-parallel: 6
       fail-fast: true
       matrix:
         php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Set cache key
         id: cache-key
-        run: echo "php-${{ matrix.php-version }}" >> $GITHUB_OUTPUT
+        run: echo "key=php-${{ matrix.php-version }}" >> $GITHUB_OUTPUT
 
       - name: Setup cache environment
         id: extcache

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
         php-version: 8.0
         extensions: grpc, protobuf
-        key: ${{ runner.os }}-php-${{ env.php-version }}-extensions-${{ env.extensions }}
+        key: php-${{ env.php-version }}-extensions-${{ env.extensions }}
     steps:
       - uses: actions/checkout@v4
 
@@ -71,7 +71,7 @@ jobs:
     env:
       MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       extensions: grpc, protobuf
-      key: ${{ runner.os }}-php-${{ matrix.php-version }}-extensions-${{ env.extensions }}
+      key: php-${{ matrix.php-version }}-extensions-${{ env.extensions }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -66,10 +66,11 @@ jobs:
 
   test:
     strategy:
-      max-parallel: 6
+      max-parallel: 1
       fail-fast: true
       matrix:
-        php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-version: ['7.4', '8.4']
+        #php-version: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
     runs-on: ubuntu-24.04
 
     env:


### PR DESCRIPTION
Try caching the PHP extensions since they take a long time to
build. We try this both in the lint job and test job.

We also temporarily reduce the number of versions under test in
 order to increase velocity.