### PR TITLE
chore: add placeholders to avoid future merge conflicts

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -1674,6 +1674,8 @@ class CacheClient implements LoggerAwareInterface
         return $this->setLengthAsync($cacheName, $setName)->wait();
     }
 
+    // placeholder: sortedSetLengthByScore
+
     /**
      * Remove an element from a set.
      *
@@ -1774,6 +1776,10 @@ class CacheClient implements LoggerAwareInterface
         return $this->sortedSetPutElementAsync($cacheName, $sortedSetName, $value, $score, $ttl)->wait();
     }
 
+    // placeholder: sortedSetPutElements
+
+    // placeholder: sortedSetIncrementScore
+
     /**
      * Fetch the elements in a sorted set by index (rank).
      *
@@ -1842,6 +1848,8 @@ class CacheClient implements LoggerAwareInterface
     {
         return $this->sortedSetFetchByRankAsync($cacheName, $sortedSetName, $startRank, $endRank, $order)->wait();
     }
+
+    // placeholder: sortedSetFetchByScore
 
     /**
      * Get the score associated with a value in a sorted set.
@@ -1952,6 +1960,8 @@ class CacheClient implements LoggerAwareInterface
     {
         return $this->sortedSetRemoveElementAsync($cacheName, $sortedSetName, $value)->wait();
     }
+
+    // placeholder: sortedSetRemoveElements
 
     /**
      * Gets the cache values stored for given keys.

--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -3239,6 +3239,8 @@ class SetRemoveElementError extends SetRemoveElementResponse
     use ErrorBody;
 }
 
+// placeholder: sortedSetLengthByScore
+
 /**
  * Parent response type for a sorted set put element request. The
  * response object is resolved to a type-safe object of one of
@@ -3296,6 +3298,8 @@ class SortedSetPutElementError extends SortedSetPutElementResponse
 {
     use ErrorBody;
 }
+
+// placeholder: sortedSetIncrementScoreResponse
 
 /**
  * Parent response type for a sorted set fetch request. The
@@ -3557,6 +3561,8 @@ abstract class SortedSetRemoveElementResponse extends ResponseBase
 class SortedSetRemoveElementSuccess extends SortedSetRemoveElementResponse
 {
 }
+
+// placeholder: sortedSetRemoveElementsResponse
 
 /**
  * Contains information about an error returned from the request.

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -3094,7 +3094,9 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asMiss(), "Expected a miss but got $response.");
     }
 
-    public function testSortedSetAddElement_HappyPath()
+    // placeholder: sortedSetLengthByScore
+    
+    public function testSortedSetPutElement_HappyPath()
     {
         $sortedSetName = uniqid();
         $value = uniqid();
@@ -3112,7 +3114,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals($score, $valuesArray[$value], "The score for value '$value' does not match the expected score.");
     }
 
-    public function testSortedSetAddElementWithNonexistentCache_ThrowsException()
+    public function testSortedSetPutElementWithNonexistentCache_ThrowsException()
     {
         $cacheName = uniqid();
         $sortedSetName = uniqid();
@@ -3123,7 +3125,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals(MomentoErrorCode::CACHE_NOT_FOUND_ERROR, $response->asError()->errorCode());
     }
 
-    public function testSortedSetAddElementWithNullCacheName_ThrowsException()
+    public function testSortedSetPutElementWithNullCacheName_ThrowsException()
     {
         $sortedSetName = uniqid();
         $value = uniqid();
@@ -3133,7 +3135,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
 
-    public function testSortedSetAddElementWithEmptyCacheName_ThrowsException()
+    public function testSortedSetPutElementWithEmptyCacheName_ThrowsException()
     {
         $sortedSetName = uniqid();
         $value = uniqid();
@@ -3143,7 +3145,7 @@ class CacheClientTest extends TestCase
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
 
-    public function testSortedSetAddElementWithEmptyValue_ThrowsException()
+    public function testSortedSetPutElementWithEmptyValue_ThrowsException()
     {
         $sortedSetName = uniqid();
         $score = 1.0;
@@ -3151,6 +3153,10 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
+
+    // placeholder: sortedSetPutElements
+
+    // placeholder: sortedSetIncrementScore
 
     public function testSortedSetFetchByRank_HappyPath()
     {
@@ -3297,6 +3303,8 @@ class CacheClientTest extends TestCase
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
 
+    // placeholder: sortedSetFetchByScore
+    
     public function testSortedSetRemoveElement_HappyPath()
     {
         $sortedSetName = uniqid();
@@ -3349,6 +3357,8 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }
+
+    // placeholder: sortedSetRemoveElements
 
     public function testSortedSetGetScore_HappyPath()
     {


### PR DESCRIPTION
We add placeholders for future work to avoid clobbering each other in
upcoming PRs.

When writing new features, replace the placeholder comment with the
new code.
