### PR TITLE
fix: initializing typed property  in sortedSetFetchHit

### DIFF
--- a/src/Cache/CacheOperationTypes/CacheOperationTypes.php
+++ b/src/Cache/CacheOperationTypes/CacheOperationTypes.php
@@ -3422,7 +3422,7 @@ abstract class SortedSetFetchResponse extends ResponseBase
  */
 class SortedSetFetchHit extends SortedSetFetchResponse
 {
-    private array $elements;
+    private array $elements = [];
 
     public function __construct(_SortedSetFetchResponse $response)
     {


### PR DESCRIPTION
## PR Description:
When trying to use the SortedFetchHit response in the drop-in client, I get this error:

```
Error : Typed property Momento\Cache\CacheOperationTypes\SortedSetFetchHit::$elements must not be accessed before initialization
```

This commit is an attempt to fix that error message. 