### PR TITLE
fix: stop using is_string() for validation

### DIFF
--- a/src/Utilities/_DataValidation.php
+++ b/src/Utilities/_DataValidation.php
@@ -16,9 +16,11 @@ if (!function_exists('validateTtl')) {
 }
 
 if (!function_exists('isNullOrEmpty')) {
-    function isNullOrEmpty(?string $str = null): bool
+    function isNullOrEmpty($value): bool
     {
-        return (is_null($str) || $str === "");
+        // if the value is not null, check if the string value is empty. This covers strings that have been
+        // automatically converted into integers. Scalars cover int, float, string, and bool.
+        return is_null($value) || (is_scalar($value) && strval($value) === "");
     }
 }
 
@@ -68,7 +70,7 @@ if (!function_exists('validateKeys')) {
         foreach ($keys as $key) {
             // Explicitly test type of key. If someone passes us a ["a", "b", "c"] style list upstream
             // instead of a ["key"=>"val"] dict, the "keys" will be integers and we want to reject the payload.
-            if (!is_string($key) || isNullOrEmpty($key)) {
+            if (isNullOrEmpty($key)) {
                 throw new InvalidArgumentError("Keys must all be non-empty strings");
             }
         }
@@ -196,12 +198,8 @@ if (!function_exists('validateSortedSetElements')) {
     function validateSortedSetElements(array $elements): void
     {
         foreach ($elements as $value => $score) {
-            if (!is_string($value)) {
-                throw new InvalidArgumentError("Sorted set value must be a string");
-            }
-
             if (!is_float($score)) {
-                throw new InvalidArgumentException("Sorted set score must be a float");
+                throw new InvalidArgumentError("Sorted set score must be a float");
             }
 
             validateValueName($value);
@@ -216,7 +214,7 @@ if (!function_exists('validateSortedSetValues')) {
             throw new InvalidArgumentError("sorted set values must be a non-empty array");
         }
         foreach ($values as $value) {
-            if (!is_string($value) || isNullOrEmpty($value)) {
+            if (isNullOrEmpty($value)) {
                 throw new InvalidArgumentError("sorted set values must all be non-empty strings");
             }
         }

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -2119,10 +2119,6 @@ class CacheClientTest extends TestCase
     public function testDictionarySetFieldsWithEmptyItems_IsError()
     {
         $dictionaryName = uniqid();
-        $items = [""];
-        $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
-        $this->assertNotNull($response->asError(), "Expected error but got: $response");
-        $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
 
         $items = [];
         $response = $this->client->dictionarySetFields($this->TEST_CACHE_NAME, $dictionaryName, $items, CollectionTtl::fromCacheTtl()->withNoRefreshTtlOnUpdates());
@@ -2240,7 +2236,7 @@ class CacheClientTest extends TestCase
     public function testDictionaryGetFields_HappyPath()
     {
         $dictionaryName = uniqid();
-        $field1 = uniqid();
+        $field1 = "1234"; // explicit integer-like string to make sure php casting doesn't break validation
         $field2 = uniqid();
         $field3 = uniqid();
         $value1 = uniqid();
@@ -2267,7 +2263,7 @@ class CacheClientTest extends TestCase
     public function testDictionaryGetBatchFieldsValuesArray_HappyPath()
     {
         $dictionaryName = uniqid();
-        $field1 = uniqid();
+        $field1 = "1234"; // explicit integer-like string to make sure php casting doesn't break validation
         $field2 = uniqid();
         $field3 = uniqid();
         $value1 = uniqid();


### PR DESCRIPTION
Stop using is_string() for validation as it fails for strings that have automatically been converted into integers when used as keys in associative arrays.

Update isNullOrEmpty to check if the given value is a scalar (a string, int, float, or bool) and then check if its string value is empty instead of explicitly taking a string.

Remove a dictionary set fields test case that checks for an error when given this array: [""]. PHP will implicitly treat it as this associative array: [0 => ""], which is valid with our new validation. We need to choose whether to support integer string keys or whether to be able to reject this specific type of invalid input.