### PR TITLE
chore: make order in the sorted set functions more explicit

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -1901,7 +1901,8 @@ class CacheClient implements LoggerAwareInterface
      * This rank is exclusive, i.e. the element at this rank will not be fetched.
      * Defaults to null, which fetches up until and including the last element.
      * @param ?int $order The order to fetch the elements in. Defaults to Ascending.
-     * Will be treated as ascending if SORT_ASC or higher is supplied, and descending if SORT_DESC or lower is supplied.
+     * Use SORT_ASC for ascending order, or SORT_DESC for descending order.
+     * Any other values will be treated as ascending
      * @return ResponseFuture<SortedSetFetchResponse> A waitable future which will
      * provide the result of the sorted set fetch operation upon a blocking call to wait:<br />
      * <code>$response = $responseFuture->wait();</code><br />
@@ -1939,7 +1940,8 @@ class CacheClient implements LoggerAwareInterface
      * This rank is exclusive, i.e. the element at this rank will not be fetched.
      * Defaults to null, which fetches up until and including the last element.
      * @param ?int $order The order to fetch the elements in. Defaults to Ascending.
-     * Will be treated as ascending if SORT_ASC or higher is supplied, and descending if SORT_DESC or lower is supplied.
+     * Use SORT_ASC for ascending order, or SORT_DESC for descending order.
+     * Any other values will be treated as ascending
      * @return SortedSetFetchResponse Represents the result of the sorted set fetch operation.
      * This result is resolved to a type-safe object of one of the following types:<br>
      * * SortedSetFetchHit<br>
@@ -1969,7 +1971,8 @@ class CacheClient implements LoggerAwareInterface
      * @param ?float $maxScore The maximum score (inclusive) of the
      * elements to fetch. Defaults to positive infinity.
      * @param ?int $order The order to fetch the elements in. Defaults to Ascending.
-     *  Will be treated as ascending if SORT_ASC or higher is supplied, and descending if SORT_DESC or lower is supplied.
+     * Use SORT_ASC for ascending order, or SORT_DESC for descending order.
+     * Any other values will be treated as ascending
      * @param ?int $offset The number of elements to skip before
      * returning the first element. Defaults to 0. Note: this is not the rank of
      * the first element to return, but the number of elements of the result set
@@ -2012,7 +2015,8 @@ class CacheClient implements LoggerAwareInterface
      * @param ?float $maxScore The maximum score (inclusive) of the
      * elements to fetch. Defaults to positive infinity.
      * @param ?int $order The order to fetch the elements in. Defaults to Ascending.
-     * Will be treated as ascending if SORT_ASC or higher is supplied, and descending if SORT_DESC or lower is supplied.
+     * Use SORT_ASC for ascending order, or SORT_DESC for descending order.
+     * Any other values will be treated as ascending
      * @param ?int $offset The number of elements to skip before
      * returning the first element. Defaults to 0. Note: this is not the rank of
      * the first element to return, but the number of elements of the result set

--- a/src/Cache/Internal/ScsDataClient.php
+++ b/src/Cache/Internal/ScsDataClient.php
@@ -1714,10 +1714,10 @@ class ScsDataClient implements LoggerAwareInterface
             }
             $sortedSetFetchRequest->setByIndex($byIndex);
 
-            if (is_null($order) || $order >= SORT_ASC) {
-                $sortedSetFetchRequest->setOrder(_SortedSetFetchRequest\Order::ASCENDING);
-            } else {
+            if ($order == SORT_DESC) {
                 $sortedSetFetchRequest->setOrder(_SortedSetFetchRequest\Order::DESCENDING);
+            } else {
+                $sortedSetFetchRequest->setOrder(_SortedSetFetchRequest\Order::ASCENDING);
             }
 
             $call = $this->grpcManager->client->SortedSetFetch(


### PR DESCRIPTION
change the order argument in the sorted set functions to explicitly take SORT_ASC and SORT_DESC, and treat other values as ascending. This replaces the previous logic where SORT_DESC or lower was descending, and SORT_ASC or higher was ascending. Using built-in constants in a comparison was confusing.