### PR TITLE
feat: add flags for toggling inclusivity on length by score scores

### DIFF
--- a/src/Cache/CacheClient.php
+++ b/src/Cache/CacheClient.php
@@ -2204,10 +2204,14 @@ class CacheClient implements LoggerAwareInterface
      *
      * @param string $cacheName Name of the cache that contains the sorted set.
      * @param string $sortedSetName The name of the sorted set whose length should be returned.
-     * @param ?float $minScore The minimum score (inclusive) of the
-     * elements to fetch. Defaults to negative infinity.
-     * @param ?float $maxScore The maximum score (inclusive) of the
-     * elements to fetch. Defaults to positive infinity.
+     * @param ?float $minScore The minimum score of the elements to include in the length.
+     * Defaults to negative infinity.
+     * @param bool $inclusiveMin Whether to include elements with a score equal to $minScore in the length.
+     * Defaults to true.
+     * @param ?float $maxScore The maximum score of the elements to include in the length.
+     * Defaults to positive infinity.
+     * @param bool $inclusiveMax Whether to include elements with a score equal to $maxScore in the length.
+     * Defaults to true.
      * @return ResponseFuture<SortedSetLengthByScoreResponse> A waitable future which will
      * provide the result of the sorted set length by score operation upon a blocking call to wait:<br />
      * <code>$response = $responseFuture->wait();</code><br />
@@ -2230,9 +2234,9 @@ class CacheClient implements LoggerAwareInterface
      * we implicitly wait for completion of the request on destruction of the
      * response future.
      */
-    public function sortedSetLengthByScoreAsync(string $cacheName, string $sortedSetName, ?float $minScore = null, ?float $maxScore = null): ResponseFuture
+    public function sortedSetLengthByScoreAsync(string $cacheName, string $sortedSetName, ?float $minScore = null, bool $inclusiveMin = true, ?float $maxScore = null, bool $inclusiveMax = true): ResponseFuture
     {
-        return $this->getNextDataClient()->sortedSetLengthByScore($cacheName, $sortedSetName, $minScore, $maxScore);
+        return $this->getNextDataClient()->sortedSetLengthByScore($cacheName, $sortedSetName, $minScore, $inclusiveMin, $maxScore, $inclusiveMax);
     }
 
     /**
@@ -2240,10 +2244,14 @@ class CacheClient implements LoggerAwareInterface
      *
      * @param string $cacheName Name of the cache that contains the sorted set.
      * @param string $sortedSetName The name of the sorted set whose length should be returned.
-     * @param ?float $minScore The minimum score (inclusive) of the
-     *  elements to fetch. Defaults to negative infinity.
-     * @param ?float $maxScore The maximum score (inclusive) of the
-     *  elements to fetch. Defaults to positive infinity.
+     * @param ?float $minScore The minimum score of the elements to include in the length.
+     *  Defaults to negative infinity.
+     * @param bool $inclusiveMin Whether to include elements with a score equal to $minScore in the length.
+     *  Defaults to true.
+     * @param ?float $maxScore The maximum score of the elements to include in the length.
+     *  Defaults to positive infinity.
+     * @param bool $inclusiveMax Whether to include elements with a score equal to $maxScore in the length.
+     *  Defaults to true.
      * @return SortedSetLengthByScoreResponse Represents the result of the sorted set length by score operation.
      * This result is resolved to a type-safe object of one of the following types:<br>
      * * SortedSetLengthByScoreHit<br>
@@ -2260,9 +2268,9 @@ class CacheClient implements LoggerAwareInterface
      * }
      * </code>
      */
-    public function sortedSetLengthByScore(string $cacheName, string $sortedSetName, ?float $minScore = null, ?float $maxScore = null): SortedSetLengthByScoreResponse
+    public function sortedSetLengthByScore(string $cacheName, string $sortedSetName, ?float $minScore = null, bool $inclusiveMin = true, ?float $maxScore = null, bool $inclusiveMax = true): SortedSetLengthByScoreResponse
     {
-        return $this->sortedSetLengthByScoreAsync($cacheName, $sortedSetName, $minScore, $maxScore)->wait();
+        return $this->sortedSetLengthByScoreAsync($cacheName, $sortedSetName, $minScore, $inclusiveMin, $maxScore, $inclusiveMax)->wait();
     }
 
     /**

--- a/src/Cache/Internal/ScsDataClient.php
+++ b/src/Cache/Internal/ScsDataClient.php
@@ -205,7 +205,6 @@ use Momento\Cache\CacheOperationTypes\SortedSetLengthByScoreError;
 use Momento\Cache\CacheOperationTypes\SortedSetLengthByScoreHit;
 use Momento\Cache\CacheOperationTypes\SortedSetLengthByScoreMiss;
 use Momento\Cache\CacheOperationTypes\SortedSetLengthByScoreResponse;
-use Momento\Cache\CacheOperationTypes\SortedSetLengthByScoreSuccess;
 use Momento\Cache\CacheOperationTypes\SortedSetPutElementError;
 use Momento\Cache\CacheOperationTypes\SortedSetPutElementResponse;
 use Momento\Cache\CacheOperationTypes\SortedSetPutElementsError;
@@ -293,7 +292,7 @@ class ScsDataClient implements LoggerAwareInterface
             $ttl = $this->defaultTtlSeconds;
         }
         validateTtl($ttl);
-        return (int) round($ttl * 1000);
+        return (int)round($ttl * 1000);
     }
 
     private function returnCollectionTtl(?CollectionTtl $ttl): CollectionTtl
@@ -698,12 +697,12 @@ class ScsDataClient implements LoggerAwareInterface
     /**
      * SetIfNotExists is deprecated on the service. Here we call the new SetIfAbsent
      * and return SetIfNotExists responses.
-     * @deprecated Use SetIfAbsent instead
      * @param string $cacheName
      * @param string $key
      * @param string $value
      * @param int|float|null $ttlSeconds
      * @return ResponseFuture<SetIfNotExistsResponse>
+     * @deprecated Use SetIfAbsent instead
      */
     public function setIfNotExists(string $cacheName, string $key, string $value, $ttlSeconds = null): ResponseFuture
     {
@@ -1653,7 +1652,7 @@ class ScsDataClient implements LoggerAwareInterface
     /**
      * @return ResponseFuture<SortedSetLengthByScoreResponse>
      */
-    public function sortedSetLengthByScore(string $cacheName, string $sortedSetName, ?float $minScore = null, ?float $maxScore = null): ResponseFuture
+    public function sortedSetLengthByScore(string $cacheName, string $sortedSetName, ?float $minScore = null, bool $inclusiveMin = true, ?float $maxScore = null, bool $inclusiveMax = true): ResponseFuture
     {
         try {
             validateCacheName($cacheName);
@@ -1663,12 +1662,20 @@ class ScsDataClient implements LoggerAwareInterface
             $sortedSetLengthByScoreRequest->setSetName($sortedSetName);
 
             if (!is_null($minScore)) {
-                $sortedSetLengthByScoreRequest->setInclusiveMin($minScore);
+                if ($inclusiveMin) {
+                    $sortedSetLengthByScoreRequest->setInclusiveMin($minScore);
+                } else {
+                    $sortedSetLengthByScoreRequest->setExclusiveMin($minScore);
+                }
             } else {
                 $sortedSetLengthByScoreRequest->setUnboundedMin(new _Unbounded());
             }
             if (!is_null($maxScore)) {
-                $sortedSetLengthByScoreRequest->setInclusiveMax($maxScore);
+                if ($inclusiveMax) {
+                    $sortedSetLengthByScoreRequest->setInclusiveMax($maxScore);
+                } else {
+                    $sortedSetLengthByScoreRequest->setExclusiveMax($maxScore);
+                }
             } else {
                 $sortedSetLengthByScoreRequest->setUnboundedMax(new _Unbounded());
             }
@@ -1931,7 +1938,7 @@ class ScsDataClient implements LoggerAwareInterface
 
     }
 
-    public function sortedSetRemoveElements(string $cacheName, string $sortedSetName, array $values) : ResponseFuture
+    public function sortedSetRemoveElements(string $cacheName, string $sortedSetName, array $values): ResponseFuture
     {
         try {
             validateCacheName($cacheName);
@@ -2046,7 +2053,7 @@ class ScsDataClient implements LoggerAwareInterface
         return ResponseFuture::createPending(
             function () use ($call): GetBatchResponse {
                 try {
-                    $results= [];
+                    $results = [];
                     $responses = $call->responses();
                     foreach ($responses as $response) {
                         if ($response->getResult() == ECacheResult::Hit) {

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -2728,8 +2728,6 @@ class CacheClientTest extends TestCase
         $this->assertNotNull($response->asMiss(), "Expected a miss but got $response.");
     }
 
-    // placeholder: sortedSetLengthByScore
-
     public function testSortedSetPutElement_HappyPath()
     {
         $sortedSetName = uniqid();
@@ -3554,8 +3552,26 @@ class CacheClientTest extends TestCase
         $expectedLength = 3;
         $this->assertEquals($expectedLength, $fetchedLength, "expected length of non-existent sorted set to be $expectedLength, not $fetchedLength");
 
+        // limit by min score (exclusive)
+        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, 1.0, false);
+        $this->assertNull($response->asError(), "Error occurred while fetching sorted set '$sortedSetName'");
+        $this->assertNotNull($response->asHit(), "Expected a success but got: $response");
+
+        $fetchedLength = $response->asHit()->length();
+        $expectedLength = 3;
+        $this->assertEquals($expectedLength, $fetchedLength, "expected length of non-existent sorted set to be $expectedLength, not $fetchedLength");
+
         // limit by max score
-        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, null, 3.9);
+        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, null, true, 3.9);
+        $this->assertNull($response->asError(), "Error occurred while fetching sorted set '$sortedSetName'");
+        $this->assertNotNull($response->asHit(), "Expected a success but got: $response");
+
+        $fetchedLength = $response->asHit()->length();
+        $expectedLength = 3;
+        $this->assertEquals($expectedLength, $fetchedLength, "expected length of non-existent sorted set to be $expectedLength, not $fetchedLength");
+
+        // limit by max score (exclusive)
+        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, null, true, 4.0, false);
         $this->assertNull($response->asError(), "Error occurred while fetching sorted set '$sortedSetName'");
         $this->assertNotNull($response->asHit(), "Expected a success but got: $response");
 
@@ -3564,7 +3580,16 @@ class CacheClientTest extends TestCase
         $this->assertEquals($expectedLength, $fetchedLength, "expected length of non-existent sorted set to be $expectedLength, not $fetchedLength");
 
         // limit by min and max score
-        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, 1.1, 3.9);
+        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, 1.1, true, 3.9);
+        $this->assertNull($response->asError(), "Error occurred while fetching sorted set '$sortedSetName'");
+        $this->assertNotNull($response->asHit(), "Expected a success but got: $response");
+
+        $fetchedLength = $response->asHit()->length();
+        $expectedLength = 2;
+        $this->assertEquals($expectedLength, $fetchedLength, "expected length of non-existent sorted set to be $expectedLength, not $fetchedLength");
+
+        // limit by min and max score (exclusive)
+        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, 1.0, false, 4.0, false);
         $this->assertNull($response->asError(), "Error occurred while fetching sorted set '$sortedSetName'");
         $this->assertNotNull($response->asHit(), "Expected a success but got: $response");
 
@@ -3604,7 +3629,7 @@ class CacheClientTest extends TestCase
         $sortedSetName = uniqid();
         $minScore = 100.0;
         $maxScore = 1.0;
-        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, $minScore, $maxScore);
+        $response = $this->client->sortedSetLengthByScore($this->TEST_CACHE_NAME, $sortedSetName, $minScore, true, $maxScore);
         $this->assertNotNull($response->asError(), "Expected error but got: $response");
         $this->assertEquals(MomentoErrorCode::INVALID_ARGUMENT_ERROR, $response->asError()->errorCode());
     }


### PR DESCRIPTION
Add $inclusiveMin and $inclusiveMax to sortedSetLengthByScore to allow callers to toggle whether the min and max scores should be inclusive or exclusive. They default to inclusive.

Add tests for the flags.

Minor formatting.