### PR TITLE
chore: Update the documentation comply with the PHP license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Welcome to the PHP SDK Contributing Guide :wave:
+# Welcome to the Momento SDK for PHP Contributing Guide :wave:
 
-Thank you for taking your time to contribute to our PHP SDK!
+Thank you for taking your time to contribute to our SDK!
 
 This guide will provide you information to start your own development and testing.
 
@@ -8,7 +8,7 @@ Happy coding :dancer:
 
 ## Requirements
 
-Check out our PHP SDK documentation for [requirements](https://docs.momentohq.com/sdks/php#requirements)!
+Check out our SDK documentation for [requirements](https://docs.momentohq.com/sdks/php#requirements)!
 
 ## Build Docker Image
 
@@ -18,7 +18,7 @@ You will likely need to run this only once:
 ./dev-docker-build.sh
 ```
 
-## Run Integration Test
+## Run Integration Tests
 
 ```bash
 export MOMENTO_API_KEY=<YOUR_API_KEY>

--- a/README-logging.md
+++ b/README-logging.md
@@ -1,17 +1,12 @@
-<head>
-  <meta name="Momento PHP Client Library Documentation" content="PHP client software development kit for Momento Serverless Cache">
-</head>
-<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
+# Momento SDK Logging facilities
 
-# Momento PHP SDK Logging facilities
-
-The PHP SDK uses the [PSR-3](https://www.php-fig.org/psr/psr-3/) standard to allow the use of any compatible logging
+The Momento SDK for PHP uses the [PSR-3](https://www.php-fig.org/psr/psr-3/) standard to allow the use of any compatible logging
 implementation. This means you can either use your own favorite (PSR-3) logging package for the Momento client's logging
 needs or you can use one provided by the SDK.
 
 ## SDK-provided logging
 
-The Momento PHP SDK provides a few bare-bones logger factories to provide logging facilities for the client. The
+The SDK provides a few bare-bones logger factories to provide logging facilities for the client. The
 built-in logging factories include:
 
 * Momento\Logging\StderrLoggerFactory - provides a logger that prints messages to stderr depending on the configured log level

--- a/README-proxying.md
+++ b/README-proxying.md
@@ -1,5 +1,3 @@
-<img src="https://docs.momentohq.com/img/logo.svg" alt="logo" width="400"/>
-
 # Using Momento With A Proxy
 
 Momento `CacheClient` connections can be proxied with relative ease. We'll provide an example here, using

--- a/README.template.md
+++ b/README.template.md
@@ -4,7 +4,7 @@ Japanese: [日本語](README.ja.md)
 
 ## Packages
 
-The Momento PHP SDK package is available on packagist.org: [client-sdk-php](https://packagist.org/packages/momentohq/client-sdk-php)
+The Momento SDK for PHP package is available on packagist.org: [client-sdk-php](https://packagist.org/packages/momentohq/client-sdk-php)
 
 ## Usage
 
@@ -20,11 +20,15 @@ Documentation is available on the [Momento Docs website](https://docs.momentohq.
 
 ## Examples
 
-Working example projects, with all required build configuration files, are available 
+Working example projects, with all required build configuration files, are available
 [in the examples directory](./examples/).
 
 ## Developing
 
 If you are interested in contributing to the SDK, please see the [CONTRIBUTING](./CONTRIBUTING.md) docs.
+
+## Attributions
+
+This product includes PHP software, freely available from <http://www.php.net/software/>
 
 {{ ossFooter }}


### PR DESCRIPTION
Replace language like "Momento PHP SDK" with "Momento SDK for PHP".

Add an attribution section to the README template with the required attribution statement.

Remove logo links from logging and proxying READMEs that don't render correctly on
github.