### PR TITLE
feat: add ReadConcern config

### DIFF
--- a/src/Cache/Interceptors/ReadConcernInterceptor.php
+++ b/src/Cache/Interceptors/ReadConcernInterceptor.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Momento\Cache\Interceptors;
+
+use Grpc\Interceptor;
+use Momento\Config\ReadConcern;
+
+class ReadConcernInterceptor extends Interceptor
+{
+    private string $readConcern;
+
+    public function __construct(string $readConcern)
+    {
+        $this->readConcern = $readConcern;
+    }
+
+    public function interceptUnaryUnary($method, $argument, $deserialize, $continuation, array $metadata = [], array $options = [])
+    {
+        if (!is_null($this->readConcern) && $this->readConcern !== ReadConcern::BALANCED) {
+            $metadata["read-concern"] = [$this->readConcern];
+        }
+        return parent::interceptUnaryUnary($method, $argument, $deserialize, $continuation, $metadata, $options);
+    }
+}

--- a/src/Cache/Internal/DataGrpcManager.php
+++ b/src/Cache/Internal/DataGrpcManager.php
@@ -10,6 +10,7 @@ use Grpc\Interceptor;
 use Momento\Auth\ICredentialProvider;
 use Momento\Cache\Interceptors\AgentInterceptor;
 use Momento\Cache\Interceptors\AuthorizationInterceptor;
+use Momento\Cache\Interceptors\ReadConcernInterceptor;
 use Momento\Config\IConfiguration;
 
 class DataGrpcManager
@@ -35,6 +36,7 @@ class DataGrpcManager
         $interceptors = [
             new AuthorizationInterceptor($authProvider->getAuthToken()),
             new AgentInterceptor("cache"),
+            new ReadConcernInterceptor($configuration->getReadConcern()),
         ];
         $interceptedChannel = Interceptor::intercept($this->channel, $interceptors);
 

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -15,12 +15,14 @@ class Configuration implements IConfiguration
 
     private ?ILoggerFactory $loggerFactory;
     private ?ITransportStrategy $transportStrategy;
+    private string $readConcern;
     protected static int $maxIdleMillis = 4 * 60 * 1000;
 
-    public function __construct(?ILoggerFactory $loggerFactory, ?ITransportStrategy $transportStrategy)
+    public function __construct(?ILoggerFactory $loggerFactory, ?ITransportStrategy $transportStrategy, ?string $readConcern = null)
     {
         $this->loggerFactory = $loggerFactory ?? new NullLoggerFactory();
         $this->transportStrategy = $transportStrategy;
+        $this->readConcern = $readConcern ?? ReadConcern::BALANCED;
     }
 
     /**
@@ -36,6 +38,14 @@ class Configuration implements IConfiguration
     public function getTransportStrategy(): ITransportStrategy
     {
         return $this->transportStrategy;
+    }
+
+    /**
+     * @return string The currently active read consistency configuration
+     */
+    public function getReadConcern(): string
+    {
+        return $this->readConcern;
     }
 
     /**
@@ -58,5 +68,16 @@ class Configuration implements IConfiguration
     public function withClientTimeout(int $clientTimeoutSecs): IConfiguration
     {
         return new Configuration($this->loggerFactory, $this->transportStrategy->withClientTimeout($clientTimeoutSecs));
+    }
+
+    /**
+     * Creates a new instance of the Configuration object, updated to use the specified read consistency.
+     *
+     * @param ReadConcern $readConcern The read consistency configuration to use.
+     * @return IConfiguration Configuration object with specified read concern.
+     */
+    public function withReadConcern(string $readConcern): IConfiguration
+    {
+        return new Configuration($this->loggerFactory, $this->transportStrategy, $readConcern);
     }
 }

--- a/src/Config/Configurations/InRegion.php
+++ b/src/Config/Configurations/InRegion.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Momento\Config\Configurations;
 
 use Momento\Config\Configuration;
+use Momento\Config\ReadConcern;
 use Momento\Config\Transport\StaticGrpcConfiguration;
 use Momento\Config\Transport\StaticStorageTransportStrategy;
 use Momento\Logging\ILoggerFactory;
@@ -40,6 +41,7 @@ class InRegion extends Configuration
         $loggerFactory = $loggerFactory ?? new NullLoggerFactory();
         $grpcConfig = new StaticGrpcConfiguration(1100);
         $transportStrategy = new StaticStorageTransportStrategy($grpcConfig, $loggerFactory, self::$maxIdleMillis);
-        return new self($loggerFactory, $transportStrategy);
+        $readConcern = ReadConcern::BALANCED;
+        return new self($loggerFactory, $transportStrategy, $readConcern);
     }
 }

--- a/src/Config/Configurations/Laptop.php
+++ b/src/Config/Configurations/Laptop.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Momento\Config\Configurations;
 
 use Momento\Config\Configuration;
+use Momento\Config\ReadConcern;
 use Momento\Config\Transport\StaticGrpcConfiguration;
 use Momento\Config\Transport\StaticStorageTransportStrategy;
 use Momento\Logging\ILoggerFactory;
@@ -38,6 +39,7 @@ class Laptop extends Configuration
         $loggerFactory = $loggerFactory ?? new NullLoggerFactory();
         $grpcConfig = new StaticGrpcConfiguration(5000);
         $transportStrategy = new StaticStorageTransportStrategy($grpcConfig, $loggerFactory, self::$maxIdleMillis);
-        return new Laptop($loggerFactory, $transportStrategy);
+        $readConcern = ReadConcern::BALANCED;
+        return new Laptop($loggerFactory, $transportStrategy, $readConcern);
     }
 }

--- a/src/Config/IConfiguration.php
+++ b/src/Config/IConfiguration.php
@@ -16,11 +16,15 @@ interface IConfiguration
      */
     public function getLoggerFactory(): ILoggerFactory;
 
-
     /**
      * @return ITransportStrategy The currently active transport strategy
      */
     public function getTransportStrategy(): ITransportStrategy;
+
+    /**
+     * @return int The currently active read consistency configuration
+     */
+    public function getReadConcern(): string;
 
     /**
      * Creates a new instance of the Configuration object, updated to use the specified transport strategy.
@@ -37,4 +41,12 @@ interface IConfiguration
      * @return IConfiguration Configuration object with specified client timeout
      */
     public function withClientTimeout(int $clientTimeoutSecs): IConfiguration;
+
+    /**
+     * Creates a new instance of the Configuration object, updated to use the specified read consistency.
+     *
+     * @param ReadConcern $readConcern The read consistency configuration to use.
+     * @return IConfiguration Configuration object with specified read concern.
+     */
+    public function withReadConcern(string $readConcern): IConfiguration;
 }

--- a/src/Config/ReadConcern.php
+++ b/src/Config/ReadConcern.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Momento\Config;
+
+abstract class ReadConcern
+{
+    /**
+     * BALANCED is the default read concern for the cache client.
+     */
+    public const BALANCED = "BALANCED";
+    /**
+     * CONSISTENT read concern guarantees read after write consistency.
+     */
+    public const CONSISTENT = "CONSISTENT";
+}

--- a/tests/Cache/CacheClientTest.php
+++ b/tests/Cache/CacheClientTest.php
@@ -14,6 +14,7 @@ use Momento\Cache\CacheClient;
 use Momento\Config\Configuration;
 use Momento\Config\Configurations;
 use Momento\Config\IConfiguration;
+use Momento\Config\ReadConcern;
 use Momento\Config\Transport\StaticGrpcConfiguration;
 use Momento\Config\Transport\StaticTransportStrategy;
 use Momento\Logging\NullLoggerFactory;
@@ -34,7 +35,7 @@ class CacheClientTest extends TestCase
 
     public function setUp(): void
     {
-        $this->configuration = Configurations\Laptop::latest();
+        $this->configuration = Configurations\Laptop::latest()->withReadConcern(ReadConcern::CONSISTENT);
         $this->authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         $this->client = new CacheClient($this->configuration, $this->authProvider, $this->DEFAULT_TTL_SECONDS);
         $this->TEST_CACHE_NAME = uniqid('php-integration-tests-');
@@ -68,6 +69,15 @@ class CacheClientTest extends TestCase
         $grpcConfig = new StaticGrpcConfiguration($deadline);
         $transportStrategy = new StaticTransportStrategy($grpcConfig, $loggerFactory);
         return new Configuration($loggerFactory, $transportStrategy);
+    }
+
+    public function testCreateConfigurationWithReadConcern()
+    {
+        $balancedConfig = $this->configuration->withReadConcern(ReadConcern::BALANCED);
+        $this->assertEquals($balancedConfig->getReadConcern(), ReadConcern::BALANCED);
+
+        $consistentConfig = $this->configuration->withReadConcern(ReadConcern::CONSISTENT);
+        $this->assertEquals($consistentConfig->getReadConcern(), ReadConcern::CONSISTENT);
     }
 
     public function testCreateAndCloseClient() {


### PR DESCRIPTION
Closes https://github.com/momentohq/dev-eco-issue-tracker/issues/1055 

Adds the `read-concern` header with `BALANCED` and `CONSISTENT` options to the cache configs.

Tested manually and added a test case for ensuring the read concern header can be overridden. 
Also switched the cache test client to use the consistent header to match the JS sdk, but can revert that if not needed here.