### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/src/Cache/Internal/ControlGrpcManager.php
+++ b/src/Cache/Internal/ControlGrpcManager.php
@@ -22,6 +22,10 @@ class ControlGrpcManager
     {
         $endpoint = $authProvider->getControlEndpoint();
         $channelArgs = ["credentials" => ChannelCredentials::createSsl()];
+
+        // Disable service config resolution to avoid TXT record lookup
+        $channelArgs["grpc.service_config_disable_resolution"] = true;
+
         if ($authProvider->getTrustedControlEndpointCertificateName()) {
             $channelArgs["grpc.ssl_target_name_override"] = $authProvider->getTrustedControlEndpointCertificateName();
         }

--- a/src/Cache/Internal/ControlGrpcManager.php
+++ b/src/Cache/Internal/ControlGrpcManager.php
@@ -23,7 +23,7 @@ class ControlGrpcManager
         $endpoint = $authProvider->getControlEndpoint();
         $channelArgs = [
             "credentials" => ChannelCredentials::createSsl(),
-            "grpc.service_config_disable_resolution" => "true", // Disable service config resolution to avoid TXT record lookup
+            "grpc.service_config_disable_resolution" => 1, // Disable service config resolution to avoid TXT record lookup
         ];
 
         if ($authProvider->getTrustedControlEndpointCertificateName()) {

--- a/src/Cache/Internal/ControlGrpcManager.php
+++ b/src/Cache/Internal/ControlGrpcManager.php
@@ -21,10 +21,10 @@ class ControlGrpcManager
     public function __construct(ICredentialProvider $authProvider)
     {
         $endpoint = $authProvider->getControlEndpoint();
-        $channelArgs = ["credentials" => ChannelCredentials::createSsl()];
-
-        // Disable service config resolution to avoid TXT record lookup
-        $channelArgs["grpc.service_config_disable_resolution"] = true;
+        $channelArgs = [
+            "credentials" => ChannelCredentials::createSsl(),
+            "grpc.service_config_disable_resolution" => "true", // Disable service config resolution to avoid TXT record lookup
+        ];
 
         if ($authProvider->getTrustedControlEndpointCertificateName()) {
             $channelArgs["grpc.ssl_target_name_override"] = $authProvider->getTrustedControlEndpointCertificateName();

--- a/src/Cache/Internal/DataGrpcManager.php
+++ b/src/Cache/Internal/DataGrpcManager.php
@@ -23,7 +23,7 @@ class DataGrpcManager
         $endpoint = $authProvider->getCacheEndpoint();
         $channelArgs = [
             "credentials" => ChannelCredentials::createSsl(),
-            "grpc.service_config_disable_resolution" => "true", // Disable service config resolution to avoid TXT record lookup
+            "grpc.service_config_disable_resolution" => 1, // Disable service config resolution to avoid TXT record lookup
         ];
 
         if ($authProvider->getTrustedCacheEndpointCertificateName()) {

--- a/src/Cache/Internal/DataGrpcManager.php
+++ b/src/Cache/Internal/DataGrpcManager.php
@@ -21,10 +21,10 @@ class DataGrpcManager
     public function __construct(ICredentialProvider $authProvider, IConfiguration $configuration)
     {
         $endpoint = $authProvider->getCacheEndpoint();
-        $channelArgs = ["credentials" => ChannelCredentials::createSsl()];
-
-        // Disable service config resolution to avoid TXT record lookup
-        $channelArgs["grpc.service_config_disable_resolution"] = true;
+        $channelArgs = [
+            "credentials" => ChannelCredentials::createSsl(),
+            "grpc.service_config_disable_resolution" => "true", // Disable service config resolution to avoid TXT record lookup
+        ];
 
         if ($authProvider->getTrustedCacheEndpointCertificateName()) {
             $channelArgs["grpc.ssl_target_name_override"] = $authProvider->getTrustedCacheEndpointCertificateName();

--- a/src/Cache/Internal/DataGrpcManager.php
+++ b/src/Cache/Internal/DataGrpcManager.php
@@ -22,6 +22,10 @@ class DataGrpcManager
     {
         $endpoint = $authProvider->getCacheEndpoint();
         $channelArgs = ["credentials" => ChannelCredentials::createSsl()];
+
+        // Disable service config resolution to avoid TXT record lookup
+        $channelArgs["grpc.service_config_disable_resolution"] = true;
+
         if ($authProvider->getTrustedCacheEndpointCertificateName()) {
             $channelArgs["grpc.ssl_target_name_override"] = $authProvider->getTrustedCacheEndpointCertificateName();
         }


### PR DESCRIPTION
## PR Description:
- Based on the commit [here](https://github.com/googleapis/gax-php/pull/240/files), dynamic txt lookup for dns resolution flag is disabled by default in grpc-php. 
- This commit explicitly disables it too.

### tcpdump when running existing example without adding the flag explicitly:
```
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.57231: [udp sum ok] 2987 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.61836: [udp sum ok] 39756 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
    10.0.0.249.49579 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 14545+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.49579: [udp sum ok] 14545 q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
```
Observe no txt lookups with current version of php sdk [(v 1.16.0)](https://github.com/momentohq/client-sdk-php/releases/tag/v1.16.0)


### Relevant Research Links:
https://github.com/googleapis/gax-php/pull/240/files


## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1132