### PR TITLE
fix: convert non-OK batch stream statuses into SDK errors

### DIFF
--- a/src/Cache/Internal/ScsDataClient.php
+++ b/src/Cache/Internal/ScsDataClient.php
@@ -2202,6 +2202,11 @@ class ScsDataClient implements LoggerAwareInterface
                         }
                         $results[] = $value;
                     }
+
+                    $status = $call->getStatus();
+                    if ($status->code !== 0) {
+                        return new GetBatchError(_ErrorConverter::convert($status, $call->getMetadata()));
+                    }
                     return new GetBatchSuccess($results);
                 } catch (SdkError $e) {
                     return new GetBatchError($e);
@@ -2257,8 +2262,8 @@ class ScsDataClient implements LoggerAwareInterface
                     }
 
                     $status = $call->getStatus();
-                    if ($status->code != 0) {
-                        return new SetBatchError(new UnknownError($status->details));
+                    if ($status->code !== 0) {
+                        return new SetBatchError(_ErrorConverter::convert($status, $call->getMetadata()));
                     }
                     return new SetBatchSuccess($results);
                 } catch (SdkError $e) {


### PR DESCRIPTION
`getBatch` never checks the call's terminal status, so a stream ending with a non-OK grpc-status is reported as a successful batch containing only the items that arrived before the failure. `setBatch` checks it but wraps every failure in a generic `UnknownError`. Both methods now convert non-OK statuses through `_ErrorConverter` into the typed SDK errors that unary calls produce.